### PR TITLE
Implement channel closing

### DIFF
--- a/protocol/api.proto
+++ b/protocol/api.proto
@@ -21,7 +21,7 @@ message Command {
     OpenChannelRes openChanRes = 4;
 
     CloseChannel closeChan = 5;
-    CloseChannel closeChanRes = 6;
+    CloseChannelRes closeChanRes = 6;
 
     ContainerState containerState = 9;
     PortOpen portOpen = 10;
@@ -318,6 +318,8 @@ message OpenChannel {
 
   enum Action { CREATE = 0; ATTACH = 1; ATTACH_OR_CREATE = 2; }
   Action action = 3;
+
+  int32 id = 4;
 }
 
 message OpenChannelRes {
@@ -329,7 +331,19 @@ message OpenChannelRes {
   string error = 3;
 }
 
-message CloseChannel { int32 id = 1; }
+message CloseChannel {
+  int32 id = 1;
+
+  enum Action { DISCONNECT = 0; TRY_CLOSE = 1; CLOSE = 2; }
+  Action action = 2;
+}
+
+message CloseChannelRes {
+  int32 id = 1;
+
+  enum Status { DISCONNECT = 0; CLOSE = 1; NOTHING = 2; }
+  Status status = 2;
+}
 
 message ContainerState {
   enum State { SLEEP = 0; READY = 1; }
@@ -392,6 +406,7 @@ message Roster { repeated User user = 1; }
 message Exec {
   repeated string args = 1;
   map<string, string> env = 2;
+  bool blocking = 3;
 }
 
 message Package {

--- a/src/client.ts
+++ b/src/client.ts
@@ -286,7 +286,7 @@ class Client extends EventEmitter {
           throw new Error('Expected closeChanRes');
         }
 
-        this.closeChannel(cmd.closeChanRes);
+        this.handleCloseChannel(cmd.closeChanRes);
 
         break;
       default:
@@ -308,12 +308,12 @@ class Client extends EventEmitter {
     channel.onOpen(id, state, this.send);
   };
 
-  private closeChannel = ({ id }: api.ICloseChannel) => {
-    if (!id) {
-      return;
+  private handleCloseChannel = ({ id, status }: api.ICloseChannelRes) => {
+    if (id == null) {
+      throw new Error('Closing channel with no id?');
     }
 
-    this.channels[id].onClose();
+    this.channels[id].onClose({ id, status });
 
     delete this.channels[id];
   };
@@ -338,7 +338,7 @@ class Client extends EventEmitter {
       // so that we can retry without losing queued up
       // messages.
       Object.keys(this.channels).forEach((id) => {
-        this.closeChannel({ id: Number(id) });
+        this.handleCloseChannel({ id: Number(id) });
       });
     }
 


### PR DESCRIPTION
We implemented real channel closing recently. In short channel closing on crosis means you don't care about this channel anymore, you will disconnect from it and if there are no other clients connected to that channel the channel will be killed.


Channel closing provides a flexible way for a client to stop talking to a
service. This service can either be destroy from the close or kept alive in the
background. It's important to note that a channel will never be closed out from
under a client who holds a reference to that channel.

A service instance will receive a `closeChan` message when its channel is
closed. Any services which require internal cleanup should perform that here.
As with `openChan`, the passed in writer will be the broadcast writer. The
broadcast writer will be held open until the handle function returns, after that
it is an error to write to the broadcast writer. For most simple services it is
safe to ignore this message as the service instance will dropped and garbage
collected.

Anonymous channels will also be automatically closed when the corresponding
client is disconnected. This sends a `closeChan` message to the service the same
way a explicitly closing the channel would. In this case the action of the
`closeChan` sent to the service is `DISCONNECT`.

A `closeChan` command takes a few different forms depending on the provided
action:

- `DISCONNECT`: will remove the sending client from the channel. The
  `closeChanRes`'s status will always be `DISCONNECT`.
- `TRY_CLOSE`: **This is what this client uses**. Will remove the sending client from the channel. If the channel
  has no other connected clients it will be closed. This means the channel will
  only be closed if we are the last connected client. The `closeChanRes` will
  have a status of either `DISCONNECT` or `CLOSE` depending on what happened.
- `CLOSE`: will, if possible, close the underlying channel removing the client
  from the channel in the process. If it is not possible to close the channel
  (someone else is connected) then nothing will happen. The `closeChanRes`'s
  status will eitehr be `CLOSE` or `NOTHING`.

A channel close message should look like:

```
{
  channel: 0,
  closeChan: {
    id: <chan id>,
    action: DISCONNECT | TRY_CLOSE | CLOSE,
  },
  ref: "[ref]"
}
```

which will send back:

```
{
  channel: 0,
  closeChanRes: {
    id: <chan id>,
    status: DISCONNECT | CLOSE | NOTHING,
  },
  ref: "[ref]",
}
```

once closing completes. Closing will never error.