### PR TITLE
Allow minor versions of the protocol package

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "engine.io-client": "^3.4.0"
   },
   "devDependencies": {
-    "@replit/protocol": "0.0.x",
+    "@replit/protocol": "0.x.x",
     "@types/engine.io-client": "^3.1.2",
     "@types/node": "^12.7.5",
     "@typescript-eslint/eslint-plugin": "^2.3.0",
@@ -42,6 +42,6 @@
     "typescript": "^3.6.4"
   },
   "peerDependencies": {
-    "@replit/protocol": "0.0.x"
+    "@replit/protocol": "0.x.x"
   }
 }


### PR DESCRIPTION
Why
===
Minor semver bumps should be backwards compatible.

What changed
============
Allowed `@replit/protocol` peer dependency for any minor version `0.x.x`

Test plan
=========
Install crosis in a repo where it has `0.1.0` of `@replit/protocol`, yarn doesn't yell about unmet dependencies