### PR TITLE
Allow setting the debugging function outside of the constructor

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -228,12 +228,18 @@ export class Client extends EventEmitter {
     return chan;
   }
 
+  /** Gets the token that was used to connect */
   public getToken(): string | null {
     if (!this.token) {
       return null;
     }
 
     return this.token;
+  }
+
+  /** Sets a logging/debugging function */
+  public setDebugFunc(debugFunc: DebugFunc): void {
+    this.debug = debugFunc;
   }
 
   private send = (cmd: api.Command) => {


### PR DESCRIPTION
Why
===
It would be nice to be able to set it at any point in time

What changed
============
Added method to set the debug function

Test plan
=========
- Create a client without debug
- Connect
- call `client.setDebug(console.log)`
- Notice logs going to the console