### PR TITLE
Allow closing and opening to specify the actions

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -67,8 +67,13 @@ export class Channel extends EventEmitter {
 
   /**
    * Closes the channel
+   *
+   * see http://protodoc.turbio.repl.co/protov2#closing-channels
+   * @param action [[api.OpenChannel.Action]] specifies how you want to close the channel
    */
-  public close = async (): Promise<api.ICloseChannelRes> => {
+  public close = async (
+    action: api.CloseChannel.Action = api.CloseChannel.Action.TRY_CLOSE,
+  ): Promise<api.ICloseChannelRes> => {
     if (this.closed === true) {
       throw new Error('Channel already closed');
     }
@@ -76,7 +81,7 @@ export class Channel extends EventEmitter {
     const cmd = api.Command.create({
       channel: 0,
       closeChan: {
-        action: api.CloseChannel.Action.TRY_CLOSE,
+        action,
         id: this.id,
       },
     });

--- a/src/client.ts
+++ b/src/client.ts
@@ -148,6 +148,7 @@ export class Client extends EventEmitter {
    *    1- if name is specified, it will send a request with [[api.OpenChannel.Action.ATTACH_OR_CREATE]]
    *    2- if name is not specified, it will send a request with [[api.OpenChannel.Action.CREATE]]
    *
+   * http://protodoc.turbio.repl.co/protov2#opening-channels
    * @param name Channel name (can be anything)
    * @param service One of goval's services
    * @param action [[api.OpenChannel.Action]]

--- a/src/client.ts
+++ b/src/client.ts
@@ -142,23 +142,39 @@ export class Client extends EventEmitter {
   };
 
   /**
-   * Opens a service channel. If name is omitted, it will send [[api.OpenChannel.Action.CREATE]] as the action
+   * Opens a service channel.
+   * If action is specified the action will be sent with the request
+   * If action is not specfied it will:
+   *    1- if name is specified, it will send a request with [[api.OpenChannel.Action.ATTACH_OR_CREATE]]
+   *    2- if name is not specified, it will send a request with [[api.OpenChannel.Action.CREATE]]
    *
    * @param name Channel name (can be anything)
    * @param service One of goval's services
+   * @param action [[api.OpenChannel.Action]]
    */
-  public openChannel = ({ name, service }: { name?: string; service: string }): Channel => {
+  public openChannel = ({
+    name,
+    service,
+    action,
+  }: {
+    name?: string;
+    service: string;
+    action?: api.OpenChannel.Action;
+  }): Channel => {
+    let ac = action;
+    if (!ac) {
+      ac = name == null ? api.OpenChannel.Action.CREATE : api.OpenChannel.Action.ATTACH_OR_CREATE;
+    }
+
     this.debug({
       type: 'breadcrumb',
       message: 'openChannel',
       data: {
         name,
         service,
+        action: ac,
       },
     });
-
-    const action =
-      name == null ? api.OpenChannel.Action.CREATE : api.OpenChannel.Action.ATTACH_OR_CREATE;
 
     const channel = new Channel();
 
@@ -178,7 +194,7 @@ export class Client extends EventEmitter {
       openChan: {
         name,
         service,
-        action,
+        action: ac,
       },
     });
 


### PR DESCRIPTION
Why
===
Users should be able to specify the closing and opening action when they want to.
http://protodoc.turbio.repl.co/protov2#closing-channels
http://protodoc.turbio.repl.co/protov2#opening-channels

What changed
============
Added ability to specify action for closing and opening channels.

The default behavior didn't change, not specifying the action does the same thing it did before so we're backwards compatible.


Test plan
=========
Send open/close with the various actions returns the expected behavior as explained in docs