### PR TITLE
Reset timeout when we get a message and cleanup connect internal code

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -568,3 +568,30 @@ export class Client extends EventEmitter {
     ping();
   };
 }
+
+/**
+ * Emitted when there's an error while the channel is opening
+ * @asMemberOf Channel
+ * @event
+ */
+declare function close(c: { closeEvent?: CloseEvent; expected: boolean }): void;
+
+export declare interface Client extends EventEmitter {
+  on(event: 'close', listener: typeof close): this;
+  addListener(event: 'close', listener: typeof close): this;
+
+  once(event: 'close', listener: typeof close): this;
+
+  prependListener(event: 'close', listener: typeof close): this;
+
+  prependOnceListener(event: 'close', listener: typeof close): this;
+
+  off(event: 'close', listener: typeof close): this;
+  removeListener(event: 'close', listener: typeof close): this;
+
+  emit(event: 'close', ...args: Parameters<typeof close>): boolean;
+
+  removeAllListeners(event?: 'close'): this;
+
+  eventNames(): Array<'close'>;
+}


### PR DESCRIPTION
Why
===
We started sending the status of the container startup from the backend when we start a connection. After discussing with the infra team (aka mason), it made sense to reset the connection timeout as long as we're receiving something from the backend, which signifies that the connection will eventually work.

While I was implementing the above, I realized how shit the code is for `tryConnect` which is the internal connect function, it had so much indirection and wasn't the most enjoyable to read, so I refactored it. I guess I could've implemented the timeout reset feature on a separate branch but the code was too smelly :hankey: 

What changed
============
First thing I did I got rid of `deferredReady` from the client. `deferredReady` was used all over the client code because we would resolve/reject the connection promise from multiple places (indirection).

Instead, now we localized all the code for resolving the promise within the `tryConnect` function itself. We're still dealing with event emitters (the websocket and channels) so it feels like there's some indirection but it's a bit more natural now since everything is colocated in the same function.

I added code comments so you can follow along the `tryConnect` function. I'll add more info this PR as well.

Test plan
=========
Try all the possible paths of failure, they all should work.

We really need to write unit tests for this as it's easily testable!