### PR TITLE
Rework Channel & Client closing signals

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -3,9 +3,7 @@ import { api } from '@replit/protocol';
 import { ChannelCloseReason } from './closeReasons';
 
 type RequestResult = api.Command & {
-  channelClosed?: {
-    reason: ChannelCloseReason;
-  };
+  channelClosed?: ChannelCloseReason;
 };
 
 export class Channel extends EventEmitter {
@@ -158,9 +156,7 @@ export class Channel extends EventEmitter {
   public onClose = (reason: ChannelCloseReason) => {
     Object.keys(this.requestMap).forEach((ref) => {
       const requestResult = api.Command.fromObject({}) as RequestResult;
-      requestResult.channelClosed = {
-        reason,
-      };
+      requestResult.channelClosed = reason;
       this.requestMap[ref](requestResult);
       delete this.requestMap[ref];
     });

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1,13 +1,14 @@
 import { EventEmitter } from 'events';
 import { api } from '@replit/protocol';
-import ChannelCloseError from './channelCloseError';
+import { ChannelCloseReason } from './closeReasons';
+
+type RequestResult = api.Command & {
+  channelClosed?: {
+    reason: ChannelCloseReason;
+  };
+};
 
 export class Channel extends EventEmitter {
-  // static
-  public static ChannelClosedErrorMessage = 'Channel closed';
-
-  public static ChannelCloseError = ChannelCloseError;
-
   // public
   public state: api.OpenChannelRes.State.CREATED | api.OpenChannelRes.State.ATTACHED | null;
 
@@ -22,7 +23,7 @@ export class Channel extends EventEmitter {
 
   private sendToClient: (cmd: api.Command) => void;
 
-  private requestMap: { [ref: string]: { respond(cmd: api.Command): void; chanClosed(): void } };
+  private requestMap: { [ref: string]: (res: RequestResult) => void };
 
   constructor() {
     super();
@@ -51,7 +52,7 @@ export class Channel extends EventEmitter {
    * that is resolved when we get a response.
    * @param cmdJson shape of a command see [[api.ICommand]]
    */
-  public request = async (cmdJson: api.ICommand): Promise<api.Command> => {
+  public request = async (cmdJson: api.ICommand): Promise<RequestResult> => {
     // Random base36 int
     const ref = Number(
       Math.random()
@@ -60,15 +61,8 @@ export class Channel extends EventEmitter {
     ).toString(36);
     cmdJson.ref = ref;
 
-    // Create the error here so that the stack traces
-    // are a little cleaner when we throw this
-    const closeError = new Channel.ChannelCloseError(Channel.ChannelClosedErrorMessage);
-
-    return new Promise((resolve, reject) => {
-      this.requestMap[ref] = {
-        respond: resolve,
-        chanClosed: () => reject(closeError),
-      };
+    return new Promise((resolve) => {
+      this.requestMap[ref] = resolve;
 
       this.send(cmdJson);
     });
@@ -82,7 +76,7 @@ export class Channel extends EventEmitter {
    */
   public close = async (
     action: api.CloseChannel.Action = api.CloseChannel.Action.TRY_CLOSE,
-  ): Promise<api.ICloseChannelRes> => {
+  ): Promise<ChannelCloseReason> => {
     if (this.closed === true) {
       throw new Error('Channel already closed');
     }
@@ -101,8 +95,8 @@ export class Channel extends EventEmitter {
     this.closed = true;
 
     return new Promise((resolve) => {
-      this.once('close', (closeRes) => {
-        resolve(closeRes);
+      this.once('close', (reason) => {
+        resolve(reason);
       });
     });
   };
@@ -151,7 +145,7 @@ export class Channel extends EventEmitter {
     this.emit('command', cmd);
 
     if (cmd.ref && this.requestMap[cmd.ref]) {
-      this.requestMap[cmd.ref].respond(cmd);
+      this.requestMap[cmd.ref](cmd);
       delete this.requestMap[cmd.ref];
     }
   };
@@ -159,17 +153,21 @@ export class Channel extends EventEmitter {
   /**
    * @hidden should only be called by [[Client]]
    *
-   * Called when the channel is or client is closed
+   * Called when the channel or client is closed
    */
-  public onClose = (closeChanRes: api.ICloseChannelRes) => {
+  public onClose = (reason: ChannelCloseReason) => {
     Object.keys(this.requestMap).forEach((ref) => {
-      this.requestMap[ref].chanClosed();
+      const requestResult = api.Command.fromObject({}) as RequestResult;
+      requestResult.channelClosed = {
+        reason,
+      };
+      this.requestMap[ref](requestResult);
       delete this.requestMap[ref];
     });
 
     this.isOpen = false;
     this.closed = true;
-    this.emit('close', closeChanRes);
+    this.emit('close', reason);
     this.removeAllListeners();
   };
 
@@ -198,11 +196,11 @@ declare function error({ message }: { message: string }): void;
 declare function open(): void;
 
 /**
- * Emitted when there's an error while the channel is opening
+ * Emitted when a channel is closed
  * @asMemberOf Channel
  * @event
  */
-declare function close(closeChanRes: api.ICloseChannelRes): void;
+declare function close(chanCloseReason: ChannelCloseReason): void;
 
 export declare interface Channel extends EventEmitter {
   on(event: 'command', listener: typeof command): this;

--- a/src/client.ts
+++ b/src/client.ts
@@ -4,6 +4,7 @@ import { EventEmitter } from 'events';
 import { api } from '@replit/protocol';
 import { Channel } from './channel';
 import { EIOCompat } from './EIOCompat';
+import { ClientCloseReason, ChannelCloseReason } from './closeReasons';
 
 enum ConnectionState {
   CONNECTING = 0,
@@ -43,17 +44,6 @@ interface ConnectOptions {
   polling?: boolean;
   timeout?: number | null;
   WebSocketClass?: typeof WebSocket;
-}
-
-enum ClientCloseReason {
-  /**
-   * called `client.close`
-   */
-  Intentional,
-  /**
-   * The websocket connection died
-   */
-  Disconnected,
 }
 
 /**
@@ -391,7 +381,16 @@ export class Client extends EventEmitter {
           throw new Error('Expected closeChanRes');
         }
 
-        this.handleCloseChannel(cmd.closeChanRes);
+        if (cmd.closeChanRes.id == null || cmd.closeChanRes.status == null) {
+          throw new Error(
+            `Expected id and status in closeChanRes, got ${cmd.closeChanRes.id} and ${cmd.closeChanRes.status}`,
+          );
+        }
+
+        this.handleCloseChannel(cmd.closeChanRes.id, {
+          initiator: 'channel',
+          closeStatus: cmd.closeChanRes.status,
+        });
 
         break;
       default:
@@ -417,18 +416,14 @@ export class Client extends EventEmitter {
     channel.onOpen(id, state, this.send);
   };
 
-  private handleCloseChannel = ({ id, status }: api.ICloseChannelRes) => {
+  private handleCloseChannel = (id: number, reason: ChannelCloseReason) => {
     this.debug({
       type: 'breadcrumb',
       message: 'handleCloseChannel',
-      data: { id, status },
+      data: { id, reason },
     });
 
-    if (id == null) {
-      throw new Error('Closing channel with no id?');
-    }
-
-    this.channels[id].onClose({ id, status });
+    this.channels[id].onClose(reason);
 
     delete this.channels[id];
   };
@@ -437,7 +432,10 @@ export class Client extends EventEmitter {
     this.cleanupSocket();
 
     Object.keys(this.channels).forEach((id) => {
-      this.handleCloseChannel({ id: Number(id) });
+      this.handleCloseChannel(Number(id), {
+        initiator: 'client',
+        clientCloseReason: closeResult.closeReason,
+      });
     });
 
     if (this.connectionState !== ConnectionState.DISCONNECTED) {

--- a/src/closeReasons.ts
+++ b/src/closeReasons.ts
@@ -1,0 +1,26 @@
+import { api } from '@replit/protocol';
+
+// In a separate file to circular dependencies in client and channel
+
+export enum ClientCloseReason {
+  /**
+   * called `client.close`
+   */
+  Intentional,
+  /**
+   * The websocket connection died
+   */
+  Disconnected,
+}
+
+// Channel close can either be due to client closing
+// or a close channel request
+export type ChannelCloseReason =
+  | {
+      initiator: 'client';
+      clientCloseReason: ClientCloseReason;
+    }
+  | {
+      initiator: 'channel';
+      closeStatus: api.CloseChannelRes.Status;
+    };


### PR DESCRIPTION
Basically the idea is that the current channel and client closing handling sucks. More detail here https://github.com/replit/crosis/issues/18

Client:
`client.on('close'` now emits a `CloseResult` with a close reason. Diff: https://github.com/replit/crosis/commit/367ed3cbd67d08e4a7176acd5ea85fd76b7de291

Channel Close:
`channel.on('close'` now emits a `ChannelCloseReason`
Similarly `channel.close()` now resolves with `ChannelCloseReason`

Channel Request:
And the biggest change and the real impetus for this PR is that `channel.request` now doesn't throw an error when the channel closes during a request. Instead instead of resolving an `api.Command` we resolve an extended format of `api.Command` that has an optional `channelClosed` property. See `type RequestResult`


Test plan
=========
**Client:**
1. Connect client
2. attach `close` listener to client
3. call `client.close`
4. listener gets the expected close result

Repeat above, but step 3: Close websocket abruptly

**Channel Close:**
1. Connect client
2. Open channel
3. Wait for channel to open
4. Attach `close` listener on channel
4. Do steps for client closing above
5. See expected result

Repeat above, but step 4: call `channel.close`


Channel Request:
Basically do the same as above, but before closing the channel we call `channel.request`. We expect the request result to have a truthy `channelClosed` result and containers the right reasons.