### PR TITLE
Split internal connect function from external

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "eslint-plugin-react": "^7.14.3",
     "jest": "^26.0.1",
     "parcel": "^1.12.4",
-    "prettier": "^1.18.2",
+    "prettier": "^2.0.5",
     "ts-jest": "^26.0.0",
     "typedoc": "^0.17.6",
     "typescript": "^3.9.2",

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -2,4 +2,4 @@
 echo Add a repl token to use for tests:
 read token
 
-REPL_TOKEN=$token ./node_modules/.bin/jest --no-cache test $@
+REPL_TOKEN=$token ./node_modules/.bin/jest --no-cache --detectOpenHandles test $@

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -2,4 +2,4 @@
 echo Add a repl token to use for tests:
 read token
 
-REPL_TOKEN=$token ./node_modules/.bin/jest --no-cache --detectOpenHandles test $@
+REPL_TOKEN=$token ./node_modules/.bin/jest --no-cache test $@

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -14,7 +14,7 @@ if (!REPL_TOKEN) {
 test('client connect', (done) => {
   const client = new Client();
 
-  client.connect(
+  client.open(
     {
       fetchToken: () => Promise.resolve(REPL_TOKEN),
         WebSocketClass: WebSocket,
@@ -38,7 +38,7 @@ test('channel open and close', (done) => {
 
   const channelClose = jest.fn();
 
-  client.connect(
+  client.open(
     {
       fetchToken: () => Promise.resolve(REPL_TOKEN),
         WebSocketClass: WebSocket,
@@ -86,7 +86,7 @@ test('client errors opening', (done) => {
     }
   };
 
-  client.connect({
+  client.open({
     maxConnectRetries: 0,
     fetchToken: () => Promise.resolve('test - no good'),
       WebSocketClass: WebSocket,
@@ -119,7 +119,7 @@ test('client reconnect', (done) => {
   let timesClosedUnintentionally = 0;
   let timesClosedIntentionally = 0;
 
-  client.connect(
+  client.open(
     {
       fetchToken: () => Promise.resolve(REPL_TOKEN),
         WebSocketClass: WebSocket,
@@ -188,7 +188,7 @@ test('client is closed while reconnecting', (done) => {
     return Promise.resolve(REPL_TOKEN);
   };
 
-  client.connect({
+  client.open({
     fetchToken,
     WebSocketClass: WebSocket,
   }, ({ channel }) => {
@@ -219,7 +219,7 @@ test('closing before ever connecting', () => {
   const openError = jest.fn();
   const close = jest.fn();
 
-  client.connect({
+  client.open({
     fetchToken: () => Promise.resolve(REPL_TOKEN),
       WebSocketClass: WebSocket,
   }, ({ error }) => {
@@ -245,7 +245,7 @@ test('closing before ever connecting', () => {
 test('closing client while opening', (done) => {
   const client = new Client();
 
-  client.connect({
+  client.open({
     fetchToken: () => Promise.resolve(REPL_TOKEN),
       WebSocketClass: WebSocket,
   }, () => {

--- a/src/client.ts
+++ b/src/client.ts
@@ -54,7 +54,7 @@ interface ConnectOptions {
   timeout: number | null;
   reconnect: boolean;
   WebSocketClass?: typeof WebSocket;
-  maxConnectRetries?: number;
+  maxConnectRetries: number;
 }
 
 interface ChannelRequest {
@@ -63,6 +63,9 @@ interface ChannelRequest {
   openChannelCb: OpenChannelCb;
 }
 
+/**
+ * The only required option is `fetchToken`, all others are optional and will use defaults
+ */
 interface ConnectArgs extends Partial<Omit<ConnectOptions, 'fetchToken'>> {
   fetchToken: () => Promise<string>;
 }
@@ -75,7 +78,7 @@ const maxBackoff = 15000;
  */
 const getNextRetryDelay = (retryNumber: number) => {
   const randomMs = Math.floor(Math.random() * 500);
-  const backoff = (backoffFactor ** retryNumber) * 1000;
+  const backoff = backoffFactor ** retryNumber * 1000;
 
   return Math.min(backoff, maxBackoff) + randomMs;
 };
@@ -125,7 +128,7 @@ export class Client extends EventEmitter {
 
   private ws: WebSocket | null;
 
-  private connectOptions: ConnectOptions | null;
+  private connectOptions: ConnectOptions;
 
   private chan0Cb: OpenChannelCb | null;
 
@@ -149,12 +152,30 @@ export class Client extends EventEmitter {
     return `ws${secure ? 's' : ''}://${host}:${port}/wsv2/${token}`;
   }
 
-  constructor(debug: DebugFunc = () => {}) {
+  constructor(options: ConnectArgs, debug: DebugFunc = () => {}) {
     super();
+
+    if (!options.fetchToken || typeof options.fetchToken !== 'function') {
+      const error = new Error('You must provide a fetchToken function');
+
+      debug({ type: 'breadcrumb', message: 'error', data: error.message });
+      throw error;
+    }
 
     this.ws = null;
     this.channels = {};
-    this.connectOptions = null;
+    this.connectOptions = {
+      polling: false,
+      timeout: 10000,
+      reconnect: true,
+      maxConnectRetries: 2,
+      urlOptions: {
+        secure: false,
+        host: 'eval.repl.it',
+        port: '80',
+      },
+      ...options,
+    };
     this.chan0Cb = null;
     this.connectionState = ConnectionState.DISCONNECTED;
     this.debug = debug;
@@ -172,19 +193,16 @@ export class Client extends EventEmitter {
    * Every client automatically "has" channel 0 and can use it to open more channels.
    * See http://protodoc.turbio.repl.co/protov2 from more info
    */
-  public open = (options: ConnectArgs, cb: OpenChannelCb) => {
+  public open = (cb: OpenChannelCb) => {
     this.connectTries += 1;
-    this.debug({ type: 'breadcrumb', message: 'connect', data: { polling: options.polling } });
+    this.debug({
+      type: 'breadcrumb',
+      message: 'open',
+      data: { polling: this.connectOptions.polling },
+    });
 
     if (this.connectionState !== ConnectionState.DISCONNECTED) {
       const error = new Error('Client must be disconnected to connect');
-
-      this.debug({ type: 'breadcrumb', message: 'error', data: error.message });
-      throw error;
-    }
-
-    if (!options.fetchToken) {
-      const error = new Error('You must provide a fetchToken function');
 
       this.debug({ type: 'breadcrumb', message: 'error', data: error.message });
       throw error;
@@ -197,186 +215,9 @@ export class Client extends EventEmitter {
       throw error;
     }
 
-    const connectOptions = {
-      polling: false,
-      timeout: 10000,
-      reconnect: true,
-      maxConnectRetries: 2,
-      urlOptions: {
-        secure: false,
-        host: 'eval.repl.it',
-        port: '80',
-      },
-      ...options,
-    };
-
-    this.connectOptions = connectOptions;
     this.chan0Cb = cb;
 
-    this.connectionState = ConnectionState.CONNECTING;
-
-    this.channels = {};
-    this.channelRequests.forEach((cr) => {
-      cr.currentChannel = null;
-    });
-
-    const chan0 = new Channel({ openChannelCb: cb });
-    this.channels[0] = chan0;
-
-    const WebSocketClass = connectOptions.polling ? EIOCompat : getWebSocketClass(connectOptions);
-
-    connectOptions.fetchToken().then((token) => {
-      if (this.connectionState !== ConnectionState.CONNECTING) {
-        this.handleConnectError(new Error('Client was closed before connecting'));
-
-        return;
-      }
-
-      const connStr = Client.getConnectionStr(token, connectOptions.urlOptions);
-      const ws = new WebSocketClass(connStr);
-
-      ws.binaryType = 'arraybuffer';
-      ws.onmessage = this.onSocketMessage;
-      this.ws = ws;
-
-      /**
-       * Failure can happen due to a number of reasons
-       * 1- Abrupt socket closure
-       * 2- Timedout connection request
-       * 3- ContainerState.SLEEP command
-       * 4- User calling `close` before we connect
-       */
-      let onFailed: (err: Error) => void;
-
-      ws.onerror = () => {
-        onFailed(new Error('WebSocket errored'));
-      };
-
-      /**
-       * Abrupt socket closures should report failed
-       */
-      ws.onclose = () => {
-        onFailed(new Error('WebSocket closed before we got READY'));
-      };
-
-      /**
-       * If the user specifies a timeout we will short circuit
-       * the connection if we don't get READY from the container
-       * within the specified timeout.
-       *
-       * Every time we get a message we reset the connection timeout
-       * this is because it signifies that the connection will eventually work.
-       */
-      let resetTimeout = () => {};
-      let cancelTimeout = () => {};
-      if (options.timeout) {
-        const { timeout } = options;
-        let timeoutId: ReturnType<typeof setTimeout>; // Can also be of type `number` in the browser
-
-        cancelTimeout = () => clearTimeout(timeoutId);
-
-        resetTimeout = () => {
-          cancelTimeout();
-
-          timeoutId = setTimeout(() => {
-            this.debug({ type: 'breadcrumb', message: 'connect timeout' });
-
-            onFailed(new Error('timeout'));
-          }, timeout);
-        };
-      }
-
-      /** Listen to incoming commands
-       * Every time we get a message we reset the connection timeout (if it exists)
-       * this is because it signifies that the connection will eventually work.
-       *
-       * If we ever get a ContainterState READY we can officially
-       * say that the connection is successful and we open chan0 and other `chanReq`s
-       *
-       * If we ever get ContainterState SLEEP it means that something went wrong
-       * and connection should be dropped
-       */
-      const dispose = chan0.onCommand((cmd: api.Command) => {
-        // Everytime we get a message on channel0
-        // we will reset the timeout
-        resetTimeout();
-
-        if (cmd.containerState == null) {
-          return;
-        }
-
-        if (cmd.containerState.state == null) {
-          onFailed(new Error('Got containterState but state was not defined'));
-
-          return;
-        }
-
-        const { state } = cmd.containerState;
-
-        this.debug({
-          type: 'breadcrumb',
-          message: 'containerState',
-          data: state,
-        });
-
-        const StateEnum = api.ContainerState.State;
-
-        switch (state) {
-          case StateEnum.READY: {
-            // Once we're READY we can stop listening to incoming commands
-            dispose();
-
-            if (this.retryTimer) {
-              clearTimeout(this.retryTimer);
-            }
-            cancelTimeout();
-
-            const originalClose = this.close;
-            this.close = () => {
-              throw new Error('Cannot call close inside connect callback');
-            };
-
-            chan0.handleOpen({
-              id: 0,
-              state: api.OpenChannelRes.State.CREATED,
-              send: this.send,
-            });
-
-            this.close = originalClose;
-
-            this.connectToken = token;
-
-            this.handleConnect();
-
-            break;
-          }
-          case StateEnum.SLEEP:
-            onFailed(new Error('Got SLEEP as container state'));
-
-            break;
-
-          default:
-        }
-      });
-
-      onFailed = (error: Error) => {
-        // TODO: Details
-        // Should this also handle a fall back to polling?
-        if (this.connectTries <= connectOptions.maxConnectRetries) {
-          this.retryTimer = setTimeout(() => {
-            this.connectionState = ConnectionState.DISCONNECTED;
-            this.open(connectOptions, cb);
-          }, getNextRetryDelay(this.connectTries));
-
-          return;
-        }
-
-        cancelTimeout();
-        dispose();
-
-        this.handleConnectError(error);
-      };
-    });
+    this.connect();
   };
 
   /**
@@ -502,7 +343,7 @@ export class Client extends EventEmitter {
   public close = () => {
     this.debug({ type: 'breadcrumb', message: 'user close' });
 
-    if (!this.connectOptions) {
+    if (!this.chan0Cb) {
       throw new Error('Must call client.connect before closing');
     }
 
@@ -577,8 +418,177 @@ export class Client extends EventEmitter {
   };
 
   private connect = () => {
+    this.connectionState = ConnectionState.CONNECTING;
 
-  }
+    this.channels = {};
+    this.channelRequests.forEach((cr) => {
+      cr.currentChannel = null;
+    });
+
+    if (!this.chan0Cb) {
+      throw new Error('Expected chan0Cb');
+    }
+
+    const chan0 = new Channel({ openChannelCb: this.chan0Cb });
+    this.channels[0] = chan0;
+
+    const WebSocketClass = this.connectOptions.polling
+      ? EIOCompat
+      : getWebSocketClass(this.connectOptions);
+
+    this.connectOptions.fetchToken().then((token) => {
+      if (this.connectionState !== ConnectionState.CONNECTING) {
+        this.handleConnectError(new Error('Client was closed before connecting'));
+
+        return;
+      }
+
+      const connStr = Client.getConnectionStr(token, this.connectOptions.urlOptions);
+      const ws = new WebSocketClass(connStr);
+
+      ws.binaryType = 'arraybuffer';
+      ws.onmessage = this.onSocketMessage;
+      this.ws = ws;
+
+      /**
+       * Failure can happen due to a number of reasons
+       * 1- Abrupt socket closure
+       * 2- Timedout connection request
+       * 3- ContainerState.SLEEP command
+       * 4- User calling `close` before we connect
+       */
+      let onFailed: (err: Error) => void;
+
+      ws.onerror = () => {
+        onFailed(new Error('WebSocket errored'));
+      };
+
+      /**
+       * Abrupt socket closures should report failed
+       */
+      ws.onclose = () => {
+        onFailed(new Error('WebSocket closed before we got READY'));
+      };
+
+      /**
+       * If the user specifies a timeout we will short circuit
+       * the connection if we don't get READY from the container
+       * within the specified timeout.
+       *
+       * Every time we get a message we reset the connection timeout
+       * this is because it signifies that the connection will eventually work.
+       */
+      let resetTimeout = () => {};
+      let cancelTimeout = () => {};
+      const { timeout } = this.connectOptions;
+      if (timeout !== null) {
+        let timeoutId: ReturnType<typeof setTimeout>; // Can also be of type `number` in the browser
+
+        cancelTimeout = () => clearTimeout(timeoutId);
+
+        resetTimeout = () => {
+          cancelTimeout();
+
+          timeoutId = setTimeout(() => {
+            this.debug({ type: 'breadcrumb', message: 'connect timeout' });
+
+            onFailed(new Error('timeout'));
+          }, timeout);
+        };
+      }
+
+      /** Listen to incoming commands
+       * Every time we get a message we reset the connection timeout (if it exists)
+       * this is because it signifies that the connection will eventually work.
+       *
+       * If we ever get a ContainterState READY we can officially
+       * say that the connection is successful and we open chan0 and other `chanReq`s
+       *
+       * If we ever get ContainterState SLEEP it means that something went wrong
+       * and connection should be dropped
+       */
+      const dispose = chan0.onCommand((cmd: api.Command) => {
+        // Everytime we get a message on channel0
+        // we will reset the timeout
+        resetTimeout();
+
+        if (cmd.containerState == null) {
+          return;
+        }
+
+        if (cmd.containerState.state == null) {
+          onFailed(new Error('Got containterState but state was not defined'));
+
+          return;
+        }
+
+        const { state } = cmd.containerState;
+
+        this.debug({
+          type: 'breadcrumb',
+          message: 'containerState',
+          data: state,
+        });
+
+        const StateEnum = api.ContainerState.State;
+
+        switch (state) {
+          case StateEnum.READY: {
+            // Once we're READY we can stop listening to incoming commands
+            dispose();
+
+            if (this.retryTimer) {
+              clearTimeout(this.retryTimer);
+            }
+            cancelTimeout();
+
+            const originalClose = this.close;
+            this.close = () => {
+              throw new Error('Cannot call close inside connect callback');
+            };
+
+            chan0.handleOpen({
+              id: 0,
+              state: api.OpenChannelRes.State.CREATED,
+              send: this.send,
+            });
+
+            this.close = originalClose;
+
+            this.connectToken = token;
+
+            this.handleConnect();
+
+            break;
+          }
+          case StateEnum.SLEEP:
+            onFailed(new Error('Got SLEEP as container state'));
+
+            break;
+
+          default:
+        }
+      });
+
+      onFailed = (error: Error) => {
+        // TODO: Details
+        // Should this also handle a fall back to polling?
+        if (this.connectTries <= this.connectOptions.maxConnectRetries) {
+          this.retryTimer = setTimeout(() => {
+            this.connectionState = ConnectionState.DISCONNECTED;
+            this.connect();
+          }, getNextRetryDelay(this.connectTries));
+
+          return;
+        }
+
+        cancelTimeout();
+        dispose();
+
+        this.handleConnectError(error);
+      };
+    });
+  };
 
   private send = (cmd: api.Command) => {
     this.debug({ type: 'log', log: { direction: 'out', cmd } });
@@ -640,7 +650,8 @@ export class Client extends EventEmitter {
         }
 
         break;
-      } default:
+      }
+      default:
     }
   };
 
@@ -699,16 +710,20 @@ export class Client extends EventEmitter {
       clearTimeout(this.retryTimer);
     }
 
-    const willReconnect = closeResult.closeReason === ClientCloseReason.Disconnected &&
-      Boolean(this.connectOptions?.reconnect);
+    const willReconnect =
+      closeResult.closeReason === ClientCloseReason.Disconnected &&
+      Boolean(this.connectOptions.reconnect);
 
-    const closeReason: ChannelCloseReason = closeResult.closeReason === ClientCloseReason.Intentional ? {
-      initiator: 'client',
-      willReconnect: false,
-    } : {
-      initiator: 'client',
-      willReconnect,
-    };
+    const closeReason: ChannelCloseReason =
+      closeResult.closeReason === ClientCloseReason.Intentional
+        ? {
+            initiator: 'client',
+            willReconnect: false,
+          }
+        : {
+            initiator: 'client',
+            willReconnect,
+          };
 
     Object.values(this.channels).forEach((channel) => {
       if (channel.closed) {
@@ -728,21 +743,13 @@ export class Client extends EventEmitter {
       return;
     }
 
-    if (!this.connectOptions) {
-      throw new Error('Expected connectOptions');
-    }
-
-    if (!this.chan0Cb) {
-      throw new Error('Expected chan0Cb');
-    }
-
     if (this.connectOptions.reconnect) {
       this.debug({
         type: 'breadcrumb',
         message: 'reconnecting',
       });
 
-      this.open(this.connectOptions, this.chan0Cb);
+      this.connect();
     }
   };
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -167,12 +167,12 @@ export class Client extends EventEmitter {
   }
 
   /**
-   * Connects to the server and and opens channel 0
+   * Starts connecting to the server and and opens channel 0
    *
    * Every client automatically "has" channel 0 and can use it to open more channels.
    * See http://protodoc.turbio.repl.co/protov2 from more info
    */
-  public connect = (options: ConnectArgs, cb: OpenChannelCb) => {
+  public open = (options: ConnectArgs, cb: OpenChannelCb) => {
     this.connectTries += 1;
     this.debug({ type: 'breadcrumb', message: 'connect', data: { polling: options.polling } });
 
@@ -365,7 +365,7 @@ export class Client extends EventEmitter {
         if (this.connectTries <= connectOptions.maxConnectRetries) {
           this.retryTimer = setTimeout(() => {
             this.connectionState = ConnectionState.DISCONNECTED;
-            this.connect(connectOptions, cb);
+            this.open(connectOptions, cb);
           }, getNextRetryDelay(this.connectTries));
 
           return;
@@ -576,6 +576,10 @@ export class Client extends EventEmitter {
     ping();
   };
 
+  private connect = () => {
+
+  }
+
   private send = (cmd: api.Command) => {
     this.debug({ type: 'log', log: { direction: 'out', cmd } });
 
@@ -738,7 +742,7 @@ export class Client extends EventEmitter {
         message: 'reconnecting',
       });
 
-      this.connect(this.connectOptions, this.chan0Cb);
+      this.open(this.connectOptions, this.chan0Cb);
     }
   };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6647,10 +6647,10 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@^1.18.2:
-  version "1.18.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.18.2.tgz#6823e7c5900017b4bd3acf46fe9ac4b4d7bda9ea"
-  integrity sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==
+prettier@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.5.tgz#d6d56282455243f2f92cc1716692c08aa31522d4"
+  integrity sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==
 
 pretty-format@^25.2.1, pretty-format@^25.5.0:
   version "25.5.0"


### PR DESCRIPTION
Why
===
Having the external function and the internal reconnect function be the same makes it hard for us to reason about reconnects and stuff.

What changed
============
- Renamed public `connect` function to `open` (we can keep the public API as `connect`)
- Made a private function called `connect` that is used internally to reconnect and connect for the first time
- Client.connectOptions is not null anymore, it's always initialized, `fetchToken` is initialized with a promise that rejects
- Set `this.chan0Cb` when we disconnect without reconnecting
- Use `this.chan0Cb` to make sure the user is not calling `open` multiple times without closing

Test plan
=========
Tests pass