### PR TITLE
let channel close itself

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -232,7 +232,7 @@ export class Client extends EventEmitter {
     }
 
     return () => {
-      if (channelRequest.currentChannel !== null) {
+      if (channelRequest.currentChannel !== null && !channelRequest.currentChannel.closed) {
         channelRequest.currentChannel.close();
       }
 


### PR DESCRIPTION
Why
===

This was a scenario I missed. 

The `client.openChannel` API is optimized for continuously re-using the same channel.  But if you are reusing the same client but want to conditionally open channels upon reconnecting there needs to be a way for the channel to remove itself form the `channelRequests` array.

What changed
============

If user calls `close` callback on an already closed channel don't call close again but still remove from `channelRequests` array.

Test plan
=========

added a test
