### PR TITLE
skip channel open option

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -227,9 +227,7 @@ export class Client extends EventEmitter {
     const channelRequest: ChannelRequest = { options, openChannelCb: cb, currentChannel: null };
     this.channelRequests.push(channelRequest);
 
-    const skip = !!channelRequest.skip && channelRequest.skip();
-
-    if (!skip && this.connectionState === ConnectionState.CONNECTED) {
+    if (this.connectionState === ConnectionState.CONNECTED) {
       // We're connected, open channel
       this.handleOpenChannel(channelRequest);
     }

--- a/src/client.ts
+++ b/src/client.ts
@@ -61,6 +61,7 @@ interface ChannelRequest {
   options: ChannelOptions;
   currentChannel: Channel | null;
   openChannelCb: OpenChannelCb;
+  skip?: () => boolean;
 }
 
 /**
@@ -226,7 +227,9 @@ export class Client extends EventEmitter {
     const channelRequest: ChannelRequest = { options, openChannelCb: cb, currentChannel: null };
     this.channelRequests.push(channelRequest);
 
-    if (this.connectionState === ConnectionState.CONNECTED) {
+    const skip = !!channelRequest.skip && channelRequest.skip();
+
+    if (!skip && this.connectionState === ConnectionState.CONNECTED) {
       // We're connected, open channel
       this.handleOpenChannel(channelRequest);
     }
@@ -241,7 +244,11 @@ export class Client extends EventEmitter {
   };
 
   private handleOpenChannel = (channelRequest: ChannelRequest) => {
-    const { options, openChannelCb } = channelRequest;
+    const { options, openChannelCb, skip } = channelRequest;
+
+    if (skip && skip()) {
+      return;
+    }
 
     let { action } = options;
     if (!action) {


### PR DESCRIPTION
Why
===

I described the general problem in https://github.com/replit/crosis/pull/27. I think this change is still needed because I think it's what you would expect. But had something better in mind

Based on the user/repl connected to the container some services are relevant while others are not. And since we want to reuse the same client between connections there needs to be a way to conditionally open a channel when we connect. This could be accomplished by allowing the user to provide a `skip` function that prevents the channel from opening if it returns true. 

The client's interface is a stream of channels so `skip` can be thought of as an on/off switch.

What changed
============

Added a `skip` option to `openChannel`.

Test plan
=========

test/feedback
