### PR TITLE
fix skip option

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -61,7 +61,6 @@ interface ChannelRequest {
   options: ChannelOptions;
   currentChannel: Channel | null;
   openChannelCb: OpenChannelCb;
-  skip?: () => boolean;
 }
 
 /**
@@ -242,8 +241,9 @@ export class Client extends EventEmitter {
   };
 
   private handleOpenChannel = (channelRequest: ChannelRequest) => {
-    const { options, openChannelCb, skip } = channelRequest;
+    const { options, openChannelCb } = channelRequest;
 
+    const { skip } = options;
     if (skip && skip()) {
       return;
     }


### PR DESCRIPTION
Why
===

it wasn't actually working

What changed
============

fixed by fixing type definition and accessing `skip` on `options` object. also fixed tests to match

Test plan
=========

test
