### PR TITLE
RFC: connection context

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -414,3 +414,39 @@ test('closing client while opening', (done) => {
     },
   );
 });
+
+test('connecting with a context object', (done) => {
+  const client = new Client();
+  const user = 'abc';
+
+  client.open(
+    {
+      fetchToken: () => Promise.resolve(REPL_TOKEN),
+      WebSocketClass: WebSocket,
+      context: { user },
+    },
+    () => {},
+  );
+
+  client.openChannel(
+    {
+      service: 'shell',
+      skip: (context) => {
+        expect(context).toEqual({ user });
+
+        return false;
+      },
+    },
+    ({ error, context }) => {
+      expect(context).toEqual({ user });
+
+      if (error) {
+        // Client closed so test is done.
+        done();
+        return;
+      }
+
+      client.close();
+    },
+  );
+});


### PR DESCRIPTION
Why
===

A common thing that's coming up is getting repl/user info where channels are being opened. For example, you might want to skip opening a channel based on auth state or a repl's language capabilities. 

What changed
============

Adds an optional `context` argument when opening a client that gets passed to `skip` and `openChannel` functions.

Test plan
=========

test/feedback
