### PR TITLE
fix generic typing on context object

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -419,16 +419,18 @@ test('connecting with a context object', (done) => {
   const client = new Client();
   const user = 'abc';
 
-  client.open(
+  client.open<{ user: string }>(
     {
       fetchToken: () => Promise.resolve(REPL_TOKEN),
       WebSocketClass: WebSocket,
       context: { user },
     },
-    () => {},
+    ({ context }) => {
+      expect(context).toEqual({ user });
+    },
   );
 
-  client.openChannel(
+  client.openChannel<{ user: string }>(
     {
       service: 'shell',
       skip: (context) => {

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -9,8 +9,8 @@ export interface RequestResult extends api.Command {
 type OnCloseFn = (reason: ChannelCloseReason) => void;
 
 export type OpenChannelRes<D = any> =
-  | { error: null; channel: Channel; context?: D }
-  | { error: Error; channel: null; context?: D };
+  | { error: null; channel: Channel; context: D }
+  | { error: Error; channel: null; context: D };
 
 /**
  * This function gets called when a channel opens or there is an error opening.
@@ -44,7 +44,7 @@ export type OpenChannelRes<D = any> =
  * closeChannel() // Will call potential returned cleanup function
  *
  */
-export type OpenChannelCb = (res: OpenChannelRes) => void | OnCloseFn;
+export type OpenChannelCb<D = any> = (res: OpenChannelRes<D>) => void | OnCloseFn;
 
 export interface ChannelOptions<D = any> {
   name?: string;
@@ -163,7 +163,7 @@ export class Channel extends EventEmitter {
     id: number;
     state: api.OpenChannelRes.State.CREATED | api.OpenChannelRes.State.ATTACHED;
     send: (cmd: api.Command) => void;
-    context?: any;
+    context: any;
   }) => {
     this.id = id;
     this.sendToClient = send;
@@ -191,7 +191,7 @@ export class Channel extends EventEmitter {
    *
    * Called when the channel or client is closed
    */
-  public handleClose = (reason: ChannelCloseReason, context?: any) => {
+  public handleClose = (reason: ChannelCloseReason, context: any) => {
     Object.keys(this.requestMap).forEach((ref) => {
       const requestResult = api.Command.fromObject({}) as RequestResult;
       requestResult.channelClosed = reason;
@@ -220,8 +220,8 @@ export class Channel extends EventEmitter {
    *
    * Called when the channel has an error opening
    */
-  public handleError = (error: Error) => {
-    this.openChannelCb({ error, channel: null });
+  public handleError = (error: Error, context: any) => {
+    this.openChannelCb({ error, channel: null, context });
     this.openChannelCbClose = null;
     this.removeAllListeners();
   };


### PR DESCRIPTION
Why
===

there isn't a good way to type the `open` and `openChannel` methods

What changed
============

made those methods generic

![Screen Shot 2020-08-31 at 8 48 38 AM](https://user-images.githubusercontent.com/241024/91734098-b3dd3900-eb67-11ea-94e2-0fc5e9792ef7.png)


verifying that the context passed in matches the callback's context type
![Screen Shot 2020-08-31 at 8 47 36 AM](https://user-images.githubusercontent.com/241024/91734139-c35c8200-eb67-11ea-8fcc-a08614c2090e.png)

![Screen Shot 2020-08-31 at 8 47 48 AM](https://user-images.githubusercontent.com/241024/91734141-c35c8200-eb67-11ea-8c4c-a09dc8ae6cec.png)


Test plan
=========

test still pass
