### PR TITLE
add cleanupSocket breadcrumb

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -827,6 +827,16 @@ export class Client {
   private cleanupSocket = () => {
     const { ws } = this;
 
+    this.debug({
+      type: 'breadcrumb',
+      message: 'cleanupSocket',
+      data: {
+        hasWs: Boolean(ws),
+        readyState: ws ? ws.readyState : null,
+        connectionState: this.connectionState,
+      },
+    });
+
     if (!ws) {
       return;
     }


### PR DESCRIPTION
Why
===

need some more debugging info

What changed
============

added breadcrumb for `cleanupSocket` method

Test plan
=========

should show up in sentry
