### PR TITLE
fix utf8 strings (again!)

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -52,11 +52,7 @@ export class Channel extends EventEmitter {
    */
   public request = async (cmdJson: api.ICommand): Promise<RequestResult> => {
     // Random base36 int
-    const ref = Number(
-      Math.random()
-        .toString()
-        .split('.')[1],
-    ).toString(36);
+    const ref = Number(Math.random().toString().split('.')[1]).toString(36);
     cmdJson.ref = ref;
 
     return new Promise((resolve) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,4 @@
+import './utf8_spooky_monkeypatch'; // pbjs's utf8 decoder is borked
+
 export { Client } from './client';
 export { Channel } from './channel';

--- a/src/utf8_spooky_monkeypatch.ts
+++ b/src/utf8_spooky_monkeypatch.ts
@@ -1,0 +1,40 @@
+/**
+Looks like the homebrewed utf8 decoder of protobufjs can be a little broke
+sometimes in heavy unicode land. In here, we monkey patch protobufjs's standard
+utf8.read function to our own fixed version.
+*/
+
+/* eslint-disable import/no-extraneous-dependencies, no-eval, @typescript-eslint/ban-ts-ignore  */
+import * as utf8 from '@protobufjs/utf8';
+
+function utf8ReadFixed(buffer: Uint8Array, start: number, end: number) {
+  if (end - start < 1) {
+    return '';
+  }
+
+  let str = '';
+  for (let i = start; i < end;) {
+    const t = buffer[i++];
+    if (t < 128) {
+      str += String.fromCharCode(t);
+    } else if (t > 191 && t < 224) {
+      str += String.fromCharCode(((t & 31) << 6) | (buffer[i++] & 63));
+    } else if (t > 239 && t < 365) {
+      const t2 =
+        (((t & 7) << 18) |
+          ((buffer[i++] & 63) << 12) |
+          ((buffer[i++] & 63) << 6) |
+          (buffer[i++] & 63)) -
+        0x10000;
+      str += String.fromCharCode(0xd800 + (t2 >> 10));
+      str += String.fromCharCode(0xdc00 + (t2 & 1023));
+    } else {
+      str += String.fromCharCode(((t & 15) << 12) | ((buffer[i++] & 63) << 6) | (buffer[i++] & 63));
+    }
+  }
+
+  return str;
+}
+
+// @ts-ignore we're monkey patching!
+utf8.read = utf8ReadFixed;


### PR DESCRIPTION
Why
===

They're still broken man. Finally had some time to go spelunking around the pbjs utf8 decoder. Turns out they're super clowny :clown_face: 

What changed
============

basically just remove the weird chunking code.

Test plan
=========

after lots of fuzzing and benchmarking, only prod can tell us what's what.