### PR TITLE
clear previous retry timer when connection fails

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -595,6 +595,10 @@ export class Client {
       });
 
       onFailed = (error: Error) => {
+        if (this.retryTimer) {
+          clearTimeout(this.retryTimer);
+        }
+
         // Cleanup related to this connection try. If we retry connecting a new `WebSocket` instance
         // will be used in additon to new `cancelTimeout` and `dispose` functions.
         this.cleanupSocket();


### PR DESCRIPTION
Why
===

so the client doesn't try to connect again when closes intentionally. 

What changed
============

clear previous retry timer when the connection fails. if the client is configured to re-connect a new retryTimer will be created just below this

Test plan
=========

test pass and shouldn't see `Expected chan0Cb` error anymore
