### PR TITLE
Change some naming and redundant type check in Client

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -30,6 +30,7 @@ interface TxRx {
   direction: 'in' | 'out';
   cmd: api.Command;
 }
+
 type DebugLog =
   | {
       type: 'breadcrumb';
@@ -44,6 +45,7 @@ type DebugLog =
       type: 'ping';
       latency: number;
     };
+
 type DebugFunc = (log: DebugLog) => void;
 
 interface ConnectOptions<D = any> {
@@ -102,6 +104,10 @@ const isWebSocket = (w: unknown): w is WebSocket => {
  * @hidden
  */
 const getWebSocketClass = (options: ConnectOptions) => {
+  if (options.polling) {
+    return EIOCompat;
+  }
+
   if (options.WebSocketClass) {
     if (!isWebSocket(options.WebSocketClass)) {
       throw new Error('Passed in WebSocket does not look like a standard WebSocket');
@@ -443,9 +449,7 @@ export class Client {
     const chan0 = new Channel({ openChannelCb: this.chan0Cb });
     this.channels[0] = chan0;
 
-    const WebSocketClass = this.connectOptions.polling
-      ? EIOCompat
-      : getWebSocketClass(this.connectOptions);
+    const WebSocketClass = getWebSocketClass(this.connectOptions);
 
     this.connectOptions.fetchToken().then((token) => {
       if (this.connectionState !== ConnectionState.CONNECTING) {

--- a/src/client.ts
+++ b/src/client.ts
@@ -140,7 +140,7 @@ export class Client {
 
   private debug: DebugFunc;
 
-  private retryTimer: ReturnType<typeof setTimeout> | null;
+  private retryTimeoutId: ReturnType<typeof setTimeout> | null;
 
   private connectTries: number;
 
@@ -173,7 +173,7 @@ export class Client {
     this.debug = debug;
     this.channelRequests = [];
     this.connectTries = 0;
-    this.retryTimer = null;
+    this.retryTimeoutId = null;
     this.connectToken = null;
 
     this.debug({ type: 'breadcrumb', message: 'constructor' });
@@ -548,8 +548,8 @@ export class Client {
             // Once we're READY we can stop listening to incoming commands
             dispose();
 
-            if (this.retryTimer) {
-              clearTimeout(this.retryTimer);
+            if (this.retryTimeoutId) {
+              clearTimeout(this.retryTimeoutId);
             }
             cancelTimeout();
 
@@ -604,7 +604,7 @@ export class Client {
         // TODO: Details
         // Should this also handle a fall back to polling?
         if (this.connectTries <= this.connectOptions.maxConnectRetries) {
-          this.retryTimer = setTimeout(() => {
+          this.retryTimeoutId = setTimeout(() => {
             this.debug({
               type: 'breadcrumb',
               message: 'retrying',
@@ -745,9 +745,9 @@ export class Client {
 
     this.connectToken = null;
 
-    if (this.retryTimer) {
+    if (this.retryTimeoutId) {
       // Client was closed while reconnecting
-      clearTimeout(this.retryTimer);
+      clearTimeout(this.retryTimeoutId);
     }
 
     const willReconnect =
@@ -797,9 +797,9 @@ export class Client {
   private handleConnectError = (error: Error) => {
     this.connectToken = null;
 
-    if (this.retryTimer) {
+    if (this.retryTimeoutId) {
       // Client was closed while reconnecting
-      clearTimeout(this.retryTimer);
+      clearTimeout(this.retryTimeoutId);
     }
 
     const chan0 = this.getChannel(0);

--- a/src/client.ts
+++ b/src/client.ts
@@ -72,17 +72,17 @@ interface ConnectArgs<D> extends Partial<Omit<ConnectOptions<D>, 'fetchToken'>> 
   fetchToken: () => Promise<string>;
 }
 
-const backoffFactor = 1.7;
-const maxBackoff = 15000;
+const BACKOFF_FACTOR = 1.7;
+const MAX_BACKOFF = 15000;
 
 /**
  * @hidden
  */
 const getNextRetryDelay = (retryNumber: number) => {
   const randomMs = Math.floor(Math.random() * 500);
-  const backoff = backoffFactor ** retryNumber * 1000;
+  const backoff = BACKOFF_FACTOR ** retryNumber * 1000;
 
-  return Math.min(backoff, maxBackoff) + randomMs;
+  return Math.min(backoff, MAX_BACKOFF) + randomMs;
 };
 
 /**

--- a/src/client.ts
+++ b/src/client.ts
@@ -86,7 +86,7 @@ const getNextRetryDelay = (retryNumber: number) => {
 /**
  * @hidden
  */
-const isWebSocket = (w: typeof WebSocket | unknown) => {
+const isWebSocket = (w: unknown): w is WebSocket => {
   if (typeof w !== 'object' && typeof w !== 'function') {
     return false;
   }

--- a/src/client.ts
+++ b/src/client.ts
@@ -599,8 +599,8 @@ export class Client {
       });
 
       onFailed = (error: Error) => {
-        if (this.retryTimer) {
-          clearTimeout(this.retryTimer);
+        if (this.retryTimeoutId) {
+          clearTimeout(this.retryTimeoutId);
         }
 
         // Cleanup related to this connection try. If we retry connecting a new `WebSocket` instance


### PR DESCRIPTION
Why
===

Random assortment of changes I wanted to make after reading through the Client source more thoroughly. Will follow up with more organizational changes.

What changed
============

- `retryTimeout` -> `retryTimeoutId`
- `typeof WebSocket | unknown` -> `unknown` because the intersection of any type (except for `any`) and `unknown` is `unknown` so this type is redundant.
- Return `EIOCompat ` directly in `getWebSocketClass`
- uppercase constants

Test plan
=========

CI passes, none of this affects functionality
