### PR TITLE
Don't silently fail token requests

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -493,3 +493,26 @@ test('falling back to polling', (done) => {
     open,
   );
 });
+
+
+test('fetch token fail', (done) => {
+  const client = new Client();
+
+  client.open(
+    {
+      fetchToken: () => {
+        throw new Error('fail');
+      },
+      WebSocketClass: WebSocket,
+    },
+    ({ channel, error }) => {
+      expect(channel).toBe(null);
+      expect(error).toBeTruthy();
+      expect(error?.message).toBe('fail');
+
+      done();
+
+      return () => {};
+    },
+  );
+});


### PR DESCRIPTION
Why
===
`fetchToken` can silently fail with no recourse path. We need to report it

What changed
============
When fetch token function fails, we now call `handleConnectError` with the error, which in turn calls the channel 0 callback with the error

Test plan
=========
Wrote a test that runs through the code path. Other tests still work.