### PR TITLE
Add debug breadcrumb for every connection attempt

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -352,6 +352,17 @@ export class Client {
   };
 
   private connect = async () => {
+    this.debug({
+      type: 'breadcrumb',
+      message: 'connecting',
+      data: {
+        connectionState: this.connectionState,
+        connectTries: this.connectTries,
+        readyState: this.ws ? this.ws.readyState : undefined,
+        chan0CbExists: Boolean(this.chan0Cb),
+      },
+    });
+
     if (this.connectionState !== ConnectionState.DISCONNECTED) {
       const error = new Error('Client must be disconnected to connect');
 


### PR DESCRIPTION
Why
===

This will help us gain more insight into the total number of connection attempts, and why they fail when they do.

What changed
============

Add debug breadcrumb that gets called on every call to `connect`

Test plan
=========

We'll see this logged next time we publish
