### PR TITLE
Dont use EIOCompat WS in test env

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -3,3 +3,4 @@ echo Add a repl token to use for tests:
 read token
 
 REPL_TOKEN=$token ./node_modules/.bin/jest --no-cache test $@
+NODE_ENV="test"

--- a/src/util/helpers.ts
+++ b/src/util/helpers.ts
@@ -25,7 +25,7 @@ function isWebSocket(w: unknown): w is WebSocket {
 }
 
 export function getWebSocketClass(options: ConnectOptions) {
-  if (options.polling) {
+  if (options.polling && process.env.NODE_ENV !== 'test') {
     return EIOCompat;
   }
 


### PR DESCRIPTION
Why
===

EIOCompat WS does not work in Jest env. Let's not use it in tests.

What changed
============

Check for `process.env.NODE_ENV` before returning EIO WS when polling

Test plan
=========

"client errors opening" test no longer fails
