### PR TITLE
Add fatal function to crosis

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -227,8 +227,7 @@ test('channel skips opening conditionally', (done) => {
   );
 });
 
-// Test is broken right now because we fatal on token closures
-// also seems like the fallback code made it fail before
+// Test is broken right now due to polling fallback
 test.skip('client errors opening', (done) => {
   const fatal = jest.fn<void, [Error]>();
   const client = new Client({ fatal });

--- a/src/client.ts
+++ b/src/client.ts
@@ -92,7 +92,7 @@ export class Client {
     return `ws${secure ? 's' : ''}://${host}:${port}/wsv2/${token}`;
   }
 
-  constructor({ fatal, debug = () => {} }: { fatal: (e: Error) => void; debug: DebugFunc }) {
+  constructor({ fatal }: { fatal: (e: Error) => void; }) {
     this.ws = null;
     this.channels = {};
     this.connectOptions = {
@@ -110,7 +110,7 @@ export class Client {
     };
     this.chan0Cb = null;
     this.connectionState = ConnectionState.DISCONNECTED;
-    this.debug = debug;
+    this.debug = () => {};
     this.fatal = fatal;
     this.channelRequests = [];
     this.connectTries = 0;


### PR DESCRIPTION
Why
===
Thrown errors outside of a synchronous call are thrown into the aether and handled by the global error handler. We need a way to probe these errors and give the client's user to react to it properly.

What changed
============
- Added fatal function that's passed to the constructor
- Call fatal and return instead of throwing in places that can't be handled in a try catch around a call on the client
- Removed debug function from constructor since we just use `setDebugFunc` anyway

Test plan
=========
I added a simple test, it works. Will dig deeper into other errors 