### PR TITLE
Abort inflight token requests when closing

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,6 +10,10 @@ module.exports = {
       typescript: {},
     },
   },
+  env: {
+    "browser": true,
+    "node": true,
+  },
   rules: {
     'import/prefer-default-export': 'off',
     indent: 'off',

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "author": "faris@repl.it",
   "license": "UNLICENSED",
   "dependencies": {
+    "abortcontroller-polyfill": "^1.5.0",
     "engine.io-client": "^3.4.0"
   },
   "devDependencies": {

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 
-import { Client } from '../client';
+import { Client } from '..';
 
 // eslint-disable-next-line
 const WebSocket = require('ws');
@@ -19,7 +19,7 @@ test('client connect', (done) => {
 
   client.open(
     {
-      fetchToken: () => Promise.resolve(REPL_TOKEN),
+      fetchToken: () => Promise.resolve({ token: REPL_TOKEN, aborted: false }),
       WebSocketClass: WebSocket,
     },
     ({ channel, error }) => {
@@ -46,7 +46,7 @@ test('channel closing itself when client willReconnect', (done) => {
 
   client.open(
     {
-      fetchToken: () => Promise.resolve(REPL_TOKEN),
+      fetchToken: () => Promise.resolve({ token: REPL_TOKEN, aborted: false }),
       WebSocketClass: WebSocket,
     },
     ({ channel, error }) => {
@@ -103,7 +103,7 @@ test('channel open and close', (done) => {
 
   client.open(
     {
-      fetchToken: () => Promise.resolve(REPL_TOKEN),
+      fetchToken: () => Promise.resolve({ token: REPL_TOKEN, aborted: false }),
       WebSocketClass: WebSocket,
     },
     ({ channel, error }) => {
@@ -139,7 +139,7 @@ test('channel skips opening', (done) => {
 
   client.open(
     {
-      fetchToken: () => Promise.resolve(REPL_TOKEN),
+      fetchToken: () => Promise.resolve({ token: REPL_TOKEN, aborted: false }),
       WebSocketClass: WebSocket,
     },
     ({ error }) => {
@@ -179,7 +179,7 @@ test('channel skips opening conditionally', (done) => {
 
   client.open(
     {
-      fetchToken: () => Promise.resolve(REPL_TOKEN),
+      fetchToken: () => Promise.resolve({ token: REPL_TOKEN, aborted: false }),
       WebSocketClass: WebSocket,
     },
     ({ channel, error }) => {
@@ -251,8 +251,8 @@ test.skip('client errors opening', (done) => {
 
   client.open(
     {
-      maxConnectRetries: 1,
-      fetchToken: () => Promise.resolve('test - no good'),
+      maxConnectRetries: 0,
+      fetchToken: () => Promise.resolve({ token: 'test - no good', aborted: false }),
       WebSocketClass: WebSocket,
     },
     ({ channel, error }) => {
@@ -288,7 +288,7 @@ test('client reconnect', (done) => {
 
   client.open(
     {
-      fetchToken: () => Promise.resolve(REPL_TOKEN),
+      fetchToken: () => Promise.resolve({ token: REPL_TOKEN, aborted: false }),
       WebSocketClass: WebSocket,
     },
     ({ channel, error }) => {
@@ -354,7 +354,7 @@ test('client is closed while reconnecting', (done) => {
       });
     }
 
-    return Promise.resolve(REPL_TOKEN);
+    return Promise.resolve({ token: REPL_TOKEN, aborted: false });
   };
 
   client.open(
@@ -395,7 +395,7 @@ test('closing before ever connecting', () => {
 
   client.open(
     {
-      fetchToken: () => Promise.resolve(REPL_TOKEN),
+      fetchToken: () => Promise.resolve({ token: REPL_TOKEN, aborted: false }),
       WebSocketClass: WebSocket,
     },
     ({ error }) => {
@@ -425,7 +425,7 @@ test('closing client while opening', (done) => {
 
   client.open(
     {
-      fetchToken: () => Promise.resolve(REPL_TOKEN),
+      fetchToken: () => Promise.resolve({ token: REPL_TOKEN, aborted: false }),
       WebSocketClass: WebSocket,
     },
     () => {
@@ -446,7 +446,7 @@ test('connecting with a context object', (done) => {
 
   client.open<{ user: string }>(
     {
-      fetchToken: () => Promise.resolve(REPL_TOKEN),
+      fetchToken: () => Promise.resolve({ token: REPL_TOKEN, aborted: false }),
       WebSocketClass: WebSocket,
       context: { user },
     },
@@ -512,7 +512,7 @@ test('falling back to polling', (done) => {
 
   client.open(
     {
-      fetchToken: () => Promise.resolve('bad token'),
+      fetchToken: () => Promise.resolve({ token: 'bad token', aborted: false }),
       WebSocketClass: WebSocket,
       maxConnectRetries,
       timeout: 0,
@@ -541,5 +541,46 @@ test('fetch token fail', (done) => {
       WebSocketClass: WebSocket,
     },
     chan0Cb,
+  );
+});
+
+test('fetch abort signal works as expected', (done) => {
+  const client = new Client({
+    fatal: () => {
+      done(new Error('did not expect fatal to be called'));
+    },
+  });
+
+  const onAbort = jest.fn();
+
+  client.open(
+    {
+      fetchToken: (abortSignal) => new Promise((r) => {
+          // Listen to abort signal
+          abortSignal.onabort = () => {
+            onAbort();
+            r({
+              aborted: true,
+              token: null,
+            });
+          };
+
+          // closing client should trigger the abort signal
+          setTimeout(() => {
+            client.close();
+          }, 0);
+        }),
+      WebSocketClass: WebSocket,
+    },
+    ({ channel, error }) => {
+      expect(channel).toBe(null);
+      expect(error).toBeTruthy();
+      expect(error?.message).toBe('Channel closed');
+      expect(onAbort).toHaveBeenCalledTimes(1);
+
+      done();
+
+      return () => {};
+    },
   );
 });

--- a/src/client.ts
+++ b/src/client.ts
@@ -92,7 +92,7 @@ export class Client {
     return `ws${secure ? 's' : ''}://${host}:${port}/wsv2/${token}`;
   }
 
-  constructor({ fatal, debug = () => {} }: { fatal: (e: Error) => void; debug: DebugFunc }) {
+  constructor({ fatal }: { fatal: (e: Error) => void; }) {
     this.ws = null;
     this.channels = {};
     this.connectOptions = {
@@ -110,7 +110,7 @@ export class Client {
     };
     this.chan0Cb = null;
     this.connectionState = ConnectionState.DISCONNECTED;
-    this.debug = debug;
+    this.debug = () => {};
     this.fatal = fatal;
     this.channelRequests = [];
     this.connectTries = 0;

--- a/src/client.ts
+++ b/src/client.ts
@@ -13,7 +13,7 @@ import {
  * The only required option is `fetchToken`, all others are optional and will use defaults
  */
 interface ConnectArgs<D> extends Partial<Omit<ConnectOptions<D>, 'fetchToken'>> {
-  fetchToken: () => Promise<string>;
+  fetchToken: ConnectOptions<D>['fetchToken'];
 }
 
 type CloseResult =
@@ -86,6 +86,14 @@ export class Client {
 
   private connectToken: string | null;
 
+  /**
+   * Abort controller is used so that when the user calls
+   * client.close while we're fetching a token, we can be sure
+   * that we don't have a `connect` call lingering around waiting
+   * for a token and eventually continue on as if we still want to connect
+   */
+  private fetchTokenAbortController: AbortController | null;
+
   static getConnectionStr(token: string, urlOptions: UrlOptions) {
     const { secure, host, port } = urlOptions;
 
@@ -116,6 +124,7 @@ export class Client {
     this.connectTries = 0;
     this.retryTimeoutId = null;
     this.connectToken = null;
+    this.fetchTokenAbortController = null;
 
     this.debug({ type: 'breadcrumb', message: 'constructor' });
   }
@@ -290,6 +299,7 @@ export class Client {
       throw new Error('Must call client.connect before closing');
     }
 
+
     // TODO: wrap in `setTimeout` to make async? Would need to do this
     // to support calling `close` synchronously in `connect` callback
     // This is only an issue with channel 0 since it never closes. Other
@@ -394,11 +404,61 @@ export class Client {
 
     const WebSocketClass = getWebSocketClass(this.connectOptions);
 
-    let token: string;
+    if (this.fetchTokenAbortController) {
+      this.fatal(new Error('Expected fetchTokenAbortController to be null'));
+
+      return;
+    }
+
+    const abortController = new AbortController();
+    this.fetchTokenAbortController = abortController;
+
+    let tokenFetchResult;
     try {
-      token = await this.connectOptions.fetchToken();
+      tokenFetchResult = await this.connectOptions.fetchToken(
+        abortController.signal,
+      );
     } catch (e) {
       this.fatal(e);
+
+      return;
+    }
+
+    const { token, aborted } = tokenFetchResult;
+
+    if (abortController.signal.aborted !== aborted) {
+        // the aborted return value and the abort signal should be equivalent
+      if (abortController.signal.aborted) {
+        // In cases where our abort signal has been called means `client.close` was called
+        // that means we shouldn't be calling `handleConnectError` because chan0Cb is null!
+        this.fatal(new Error('Expected abort returned from fetchToken to be truthy when the controller aborts'));
+
+        return;
+      }
+
+      // the user shouldn't return abort without the abort signal being called, if aborting is desired
+      // client.close should be called
+      this.fatal(new Error('Abort should only be truthy returned when the abort signal is triggered'));
+
+      return;
+    }
+
+    this.fetchTokenAbortController = null;
+
+
+    if (token && aborted) {
+      this.fatal(new Error('Expected either aborted or a token'));
+    }
+
+    if (aborted) {
+      this.handleConnectError(new Error('Called client.close during while connecting'));
+
+      return;
+    }
+
+
+    if (!token) {
+      this.fatal(new Error('Expected token to be a string or request to be aborted'));
 
       return;
     }
@@ -733,7 +793,16 @@ export class Client {
   };
 
   private handleClose = (closeResult: CloseResult) => {
+    if (this.ws && this.fetchTokenAbortController) {
+      // Fetching a token is required prior to initializing a websocket, we can't
+      // have both at the same time as the abort controller is unset after we fetch the token
+      this.fatal(new Error('fetchTokenAbortController and websocket exist simultaneously'));
+
+      // Fallthrough to try to clean up
+    }
+
     this.cleanupSocket();
+
 
     this.connectToken = null;
 
@@ -746,16 +815,10 @@ export class Client {
       closeResult.closeReason === ClientCloseReason.Disconnected &&
       Boolean(this.connectOptions.reconnect);
 
-    const closeReason: ChannelCloseReason =
-      closeResult.closeReason === ClientCloseReason.Intentional
-        ? {
-            initiator: 'client',
-            willReconnect: false,
-          }
-        : {
-            initiator: 'client',
-            willReconnect,
-          };
+    const closeReason: ChannelCloseReason = {
+      initiator: 'client',
+      willReconnect,
+    };
 
     Object.values(this.channels).forEach((channel) => {
       if (channel.closed) {
@@ -769,10 +832,7 @@ export class Client {
 
     this.connectionState = ConnectionState.DISCONNECTED;
 
-    if (
-      closeResult.closeReason === ClientCloseReason.Intentional ||
-      !this.connectOptions.reconnect
-    ) {
+    if (!willReconnect) {
       // Client is done being used
       this.chan0Cb = null;
       return;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import 'abortcontroller-polyfill/dist/abortcontroller-polyfill-only';
 import './util/utf8ReadMonkeypatch'; // pbjs's utf8 decoder is borked
 
 export { Client } from './client';

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,7 +38,7 @@ export interface UrlOptions {
 }
 
 export interface ConnectOptions<D = any> {
-  fetchToken: () => Promise<string>;
+  fetchToken: (abortSignal: AbortSignal) => Promise<{ token: string | null, aborted: boolean }>;
   urlOptions: UrlOptions;
   polling: boolean;
   timeout: number | null;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1482,6 +1482,11 @@ abbrev@1:
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
 
+abortcontroller-polyfill@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/abortcontroller-polyfill/-/abortcontroller-polyfill-1.5.0.tgz#2c562f530869abbcf88d949a2b60d1d402e87a7c"
+  integrity sha512-O6Xk757Jb4o0LMzMOMdWvxpHWrQzruYBaUruFaIOfAQRnWFxfdXYobw12jrVHGtoXk6WiiyYzc0QWN9aL62HQA==
+
 acorn-globals@^4.3.0:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-4.3.4.tgz#9fa1926addc11c97308c4e66d7add0d40c3272e7"


### PR DESCRIPTION
Why
===
We can end up in a really awkward state where we call `client.close` while the client is fetching a token. When that happens, we think things are cleaned up but when the token fetch request completes we end up we throw an error and the client gets into a bad state.

What changed
============
`fetchToken` now gets an abort signal that can be used to be listened to abort or passed to a fetch function


Test plan
=========
Wrote a test for it