### PR TITLE
Slim down options surface area and fix some error handling

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -23,6 +23,10 @@ type CloseResult =
   | {
       closeReason: ClientCloseReason.Disconnected;
       wsEvent: CloseEvent | ErrorEvent;
+    }
+  | {
+      closeReason: ClientCloseReason.Error;
+      error: Error;
     };
 
 enum ConnectionState {

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,10 @@ export enum ClientCloseReason {
    * The websocket connection died
    */
   Disconnected,
+  /**
+   * The client encountered an unrecoverable/invariant error
+   */
+  Error,
 }
 
 // Channel close can either be due to client closing
@@ -40,10 +44,7 @@ export interface UrlOptions {
 export interface ConnectOptions<D = any> {
   fetchToken: (abortSignal: AbortSignal) => Promise<{ token: string | null, aborted: boolean }>;
   urlOptions: UrlOptions;
-  polling: boolean;
   timeout: number | null;
-  reconnect: boolean;
   WebSocketClass?: typeof WebSocket;
-  maxConnectRetries: number;
   context: D;
 }

--- a/src/util/helpers.ts
+++ b/src/util/helpers.ts
@@ -1,6 +1,4 @@
-/* global WebSocket */
 import { ConnectOptions } from '../types';
-import { EIOCompat } from './EIOCompat';
 
 const BACKOFF_FACTOR = 1.7;
 const MAX_BACKOFF = 15000;
@@ -25,10 +23,6 @@ function isWebSocket(w: unknown): w is WebSocket {
 }
 
 export function getWebSocketClass(options: ConnectOptions) {
-  if (options.polling) {
-    return EIOCompat;
-  }
-
   if (options.WebSocketClass) {
     if (!isWebSocket(options.WebSocketClass)) {
       throw new Error('Passed in WebSocket does not look like a standard WebSocket');
@@ -45,5 +39,5 @@ export function getWebSocketClass(options: ConnectOptions) {
     return WebSocket;
   }
 
-  throw new Error('Please pass in a WebSocket class, add it to global, or use the polling option');
+  throw new Error('Please pass in a WebSocket class or add it to global');
 }


### PR DESCRIPTION
Why
===
Options makes code harder. More concretely there was a problem with the chan0Cb being called twice when we run out of retries. We also had a problem where the client could potentially keep trying to reconnect if we call `client.close`. We are not really using those options and we wanna retry forever anyway

What changed
============
- Removed retries options, we currently set them to default. In reality we wanna retry forever until the client.close is called
- Removed polling options as it's based on maximum retries and that's removed (will revisit in the future)
- onUnrecoverableError now calls handleClose with a new close reason (Error)
- chan0Cb is not called twice when there's a an error connecting
- Calling `client.close` after the websocket connection fails doesn't keep retrying

Test plan
=========
Will follow up with a separate PR for more elaborate tests. The abort & polling tests now fails, but that's it.

For now I built dev and went to the browser to try things manually
- The client indefinitely reconnects when the handshake/ws fails
- The client eventually connects when the handshake works
- Unrecoverable errors cause the client to close and not try to reconnect

