### PR TITLE
Fix client generic context

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -43,8 +43,8 @@ export type OpenChannelCb<Ctx> = (res: OpenChannelRes<Ctx>) => void | OnCloseFn;
 type OnCloseFn = (reason: ChannelCloseReason) => void;
 
 export type OpenChannelRes<Ctx> =
-  | { error: null; channel: Channel<Ctx>; context: Ctx }
-  | { error: Error; channel: null; context: Ctx };
+  | { error: null; channel: Channel<Ctx>; context?: Ctx }
+  | { error: Error; channel: null; context?: Ctx };
 
 export class Channel<Ctx> {
   // public
@@ -157,7 +157,7 @@ export class Channel<Ctx> {
     id: number;
     state: api.OpenChannelRes.State.CREATED | api.OpenChannelRes.State.ATTACHED;
     send: (cmd: api.Command) => void;
-    context: Ctx;
+    context?: Ctx;
   }) => {
     this.id = id;
     this.sendToClient = send;
@@ -185,7 +185,7 @@ export class Channel<Ctx> {
    *
    * Called when the channel or client is closed
    */
-  public handleClose = (reason: ChannelCloseReason, context: Ctx) => {
+  public handleClose = (reason: ChannelCloseReason, context?: Ctx) => {
     Object.keys(this.requestMap).forEach((ref) => {
       const requestResult = api.Command.fromObject({}) as RequestResult;
       requestResult.channelClosed = reason;
@@ -214,7 +214,7 @@ export class Channel<Ctx> {
    *
    * Called when the channel has an error opening
    */
-  public handleError = (error: Error, context: Ctx) => {
+  public handleError = (error: Error, context?: Ctx) => {
     this.openChannelCb({ error, channel: null, context });
     this.openChannelCbClose = null;
     this.emitter.removeAllListeners();

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -43,8 +43,8 @@ export type OpenChannelCb<Ctx> = (res: OpenChannelRes<Ctx>) => void | OnCloseFn;
 type OnCloseFn = (reason: ChannelCloseReason) => void;
 
 export type OpenChannelRes<Ctx> =
-  | { error: null; channel: Channel<Ctx>; context?: Ctx }
-  | { error: Error; channel: null; context?: Ctx };
+  | { error: null; channel: Channel<Ctx>; context: Ctx }
+  | { error: Error; channel: null; context: Ctx };
 
 export class Channel<Ctx> {
   // public
@@ -157,7 +157,7 @@ export class Channel<Ctx> {
     id: number;
     state: api.OpenChannelRes.State.CREATED | api.OpenChannelRes.State.ATTACHED;
     send: (cmd: api.Command) => void;
-    context?: Ctx;
+    context: Ctx;
   }) => {
     this.id = id;
     this.sendToClient = send;
@@ -185,7 +185,7 @@ export class Channel<Ctx> {
    *
    * Called when the channel or client is closed
    */
-  public handleClose = (reason: ChannelCloseReason, context?: Ctx) => {
+  public handleClose = (reason: ChannelCloseReason, context: Ctx) => {
     Object.keys(this.requestMap).forEach((ref) => {
       const requestResult = api.Command.fromObject({}) as RequestResult;
       requestResult.channelClosed = reason;
@@ -214,7 +214,7 @@ export class Channel<Ctx> {
    *
    * Called when the channel has an error opening
    */
-  public handleError = (error: Error, context?: Ctx) => {
+  public handleError = (error: Error, context: Ctx) => {
     this.openChannelCb({ error, channel: null, context });
     this.openChannelCbClose = null;
     this.emitter.removeAllListeners();

--- a/src/client.ts
+++ b/src/client.ts
@@ -63,7 +63,7 @@ interface ChannelRequest<Ctx> {
   openChannelCb: OpenChannelCb<Ctx>;
 }
 
-export class Client<Ctx extends unknown = null> {
+export class Client<Ctx extends unknown = void> {
   public static ClientCloseReason = ClientCloseReason;
 
   public connectionState: ConnectionState;
@@ -115,12 +115,6 @@ export class Client<Ctx extends unknown = null> {
         port: '80',
       },
       fetchToken: () => Promise.reject(new Error('You must provide a fetchToken function')),
-      // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-      // @ts-ignore context is not relevant until we call the `open` function
-      // the user needs to pass it to the constructor for us to not ts-ignore
-      // this, however we don't want that because each `open` call can have a new
-      // ctx but the shape will be the same
-      context: null,
     };
     this.chan0Cb = null;
     this.connectionState = ConnectionState.DISCONNECTED;

--- a/src/client.ts
+++ b/src/client.ts
@@ -23,6 +23,10 @@ type CloseResult =
   | {
       closeReason: ClientCloseReason.Disconnected;
       wsEvent: CloseEvent | ErrorEvent;
+    }
+  | {
+      closeReason: ClientCloseReason.Error;
+      error: Error;
     };
 
 enum ConnectionState {

--- a/src/client.ts
+++ b/src/client.ts
@@ -14,6 +14,7 @@ import {
  */
 interface ConnectArgs<Ctx> extends Partial<Omit<ConnectOptions<Ctx>, 'fetchToken'>> {
   fetchToken: ConnectOptions<Ctx>['fetchToken'];
+  context: Ctx;
 }
 
 type CloseResult =
@@ -70,7 +71,7 @@ export class Client<Ctx extends unknown = null> {
 
   private ws: WebSocket | null;
 
-  private connectOptions: ConnectOptions<Ctx>;
+  private connectOptions: ConnectOptions<Ctx> | null;
 
   private chan0Cb: OpenChannelCb<Ctx> | null;
 
@@ -107,21 +108,7 @@ export class Client<Ctx extends unknown = null> {
   constructor() {
     this.ws = null;
     this.channels = {};
-    this.connectOptions = {
-      timeout: 10000,
-      urlOptions: {
-        secure: false,
-        host: 'eval.repl.it',
-        port: '80',
-      },
-      fetchToken: () => Promise.reject(new Error('You must provide a fetchToken function')),
-      // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-      // @ts-ignore context is not relevant until we call the `open` function
-      // the user needs to pass it to the constructor for us to not ts-ignore
-      // this, however we don't want that because each `open` call can have a new
-      // ctx but the shape will be the same
-      context: null,
-    };
+    this.connectOptions = null;
     this.chan0Cb = null;
     this.connectionState = ConnectionState.DISCONNECTED;
     this.debug = () => {};
@@ -164,7 +151,12 @@ export class Client<Ctx extends unknown = null> {
     }
 
     this.connectOptions = {
-      ...this.connectOptions,
+      timeout: 10000,
+      urlOptions: {
+        secure: false,
+        host: 'eval.repl.it',
+        port: '80',
+      },
       ...options,
     };
 
@@ -188,7 +180,11 @@ export class Client<Ctx extends unknown = null> {
    * http://protodoc.turbio.repl.co/protov2#opening-channels
    */
   public openChannel = (options: ChannelOptions<Ctx>, cb: OpenChannelCb<Ctx>) => {
-    const channelRequest: ChannelRequest<Ctx> = { options, openChannelCb: cb, currentChannel: null };
+    const channelRequest: ChannelRequest<Ctx> = {
+      options,
+      openChannelCb: cb,
+      currentChannel: null,
+    };
     this.channelRequests.push(channelRequest);
 
     if (this.connectionState === ConnectionState.CONNECTED) {
@@ -207,6 +203,12 @@ export class Client<Ctx extends unknown = null> {
 
   private handleOpenChannel = (channelRequest: ChannelRequest<Ctx>) => {
     const { options, openChannelCb } = channelRequest;
+
+    if (!this.connectOptions) {
+      this.onUnrecoverableError(new Error('Expected connectionOptions'));
+
+      return;
+    }
 
     const { skip } = options;
     if (skip && skip(this.connectOptions.context)) {
@@ -278,6 +280,12 @@ export class Client<Ctx extends unknown = null> {
       const { id, state, error } = cmd.openChanRes;
 
       this.debug({ type: 'breadcrumb', message: 'openChanres' });
+
+      if (!this.connectOptions) {
+        this.onUnrecoverableError(new Error('Expected connectionOptions'));
+
+        return;
+      }
 
       if (state === api.OpenChannelRes.State.ERROR) {
         this.debug({ type: 'breadcrumb', message: 'error', data: error });
@@ -428,6 +436,13 @@ export class Client<Ctx extends unknown = null> {
       throw error;
     }
 
+    if (!this.connectOptions) {
+      const error = new Error('Expected connectionOptions');
+      this.onUnrecoverableError(error);
+
+      throw error;
+    }
+
     this.connectTries += 1;
     this.connectionState = ConnectionState.CONNECTING;
 
@@ -491,7 +506,6 @@ export class Client<Ctx extends unknown = null> {
 
       return;
     }
-
 
     if (token && aborted) {
       this.onUnrecoverableError(new Error('Expected either aborted or a token'));
@@ -632,6 +646,12 @@ export class Client<Ctx extends unknown = null> {
             throw new Error('Cannot call close inside connect callback');
           };
 
+          if (!this.connectOptions) {
+            this.onUnrecoverableError(new Error('Expected connectionOptions'));
+
+            return;
+          }
+
           chan0.handleOpen({
             id: 0,
             state: api.OpenChannelRes.State.CREATED,
@@ -745,6 +765,12 @@ export class Client<Ctx extends unknown = null> {
 
         const channel = this.channels[cmd.closeChanRes.id];
 
+        if (!this.connectOptions) {
+          this.onUnrecoverableError(new Error('Expected connectionOptions'));
+
+          return;
+        }
+
         channel.handleClose(
           {
             initiator: 'channel',
@@ -849,14 +875,21 @@ export class Client<Ctx extends unknown = null> {
         return;
       }
 
+      if (!this.connectOptions) {
+        this.onUnrecoverableError(new Error('Expected connectionOptions'));
+
+        return;
+      }
+
       channel.handleClose(closeReason, this.connectOptions.context);
     });
 
     this.connectionState = ConnectionState.DISCONNECTED;
 
     if (!willReconnect) {
-      // Client is done being used
+      // Client is done being used until the next `open` call
       this.chan0Cb = null;
+      this.connectOptions = null;
       return;
     }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -63,7 +63,7 @@ interface ChannelRequest<Ctx> {
   openChannelCb: OpenChannelCb<Ctx>;
 }
 
-export class Client<Ctx extends unknown = void> {
+export class Client<Ctx extends unknown = null> {
   public static ClientCloseReason = ClientCloseReason;
 
   public connectionState: ConnectionState;
@@ -115,6 +115,12 @@ export class Client<Ctx extends unknown = void> {
         port: '80',
       },
       fetchToken: () => Promise.reject(new Error('You must provide a fetchToken function')),
+      // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+      // @ts-ignore context is not relevant until we call the `open` function
+      // the user needs to pass it to the constructor for us to not ts-ignore
+      // this, however we don't want that because each `open` call can have a new
+      // ctx but the shape will be the same
+      context: null,
     };
     this.chan0Cb = null;
     this.connectionState = ConnectionState.DISCONNECTED;

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,10 @@ export enum ClientCloseReason {
    * The websocket connection died
    */
   Disconnected,
+  /**
+   * The client encountered an unrecoverable/invariant error
+   */
+  Error,
 }
 
 // Channel close can either be due to client closing
@@ -40,10 +44,7 @@ export interface UrlOptions {
 export interface ConnectOptions<D = any> {
   fetchToken: (abortSignal: AbortSignal) => Promise<{ token: string | null, aborted: boolean }>;
   urlOptions: UrlOptions;
-  polling: boolean;
   timeout: number | null;
-  reconnect: boolean;
   WebSocketClass?: typeof WebSocket;
-  maxConnectRetries: number;
   context: D;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,3 @@
-/* global WebSocket */
 import { api } from '@replit/protocol';
 
 export enum ClientCloseReason {
@@ -28,11 +27,11 @@ export type ChannelCloseReason =
       willReconnect: false;
     };
 
-export interface ChannelOptions<D = any> {
+export interface ChannelOptions<Ctx> {
   name?: string;
   service: string;
   action?: api.OpenChannel.Action;
-  skip?: (context: D) => boolean;
+  skip?: (context: Ctx) => boolean;
 }
 
 export interface UrlOptions {
@@ -41,10 +40,10 @@ export interface UrlOptions {
   port: string;
 }
 
-export interface ConnectOptions<D = any> {
+export interface ConnectOptions<Ctx> {
   fetchToken: (abortSignal: AbortSignal) => Promise<{ token: string | null, aborted: boolean }>;
   urlOptions: UrlOptions;
   timeout: number | null;
   WebSocketClass?: typeof WebSocket;
-  context: D;
+  context: Ctx;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,7 +31,7 @@ export interface ChannelOptions<Ctx> {
   name?: string;
   service: string;
   action?: api.OpenChannel.Action;
-  skip?: (context?: Ctx) => boolean;
+  skip?: (context: Ctx) => boolean;
 }
 
 export interface UrlOptions {
@@ -45,5 +45,5 @@ export interface ConnectOptions<Ctx> {
   urlOptions: UrlOptions;
   timeout: number | null;
   WebSocketClass?: typeof WebSocket;
-  context?: Ctx;
+  context: Ctx;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,7 +31,7 @@ export interface ChannelOptions<Ctx> {
   name?: string;
   service: string;
   action?: api.OpenChannel.Action;
-  skip?: (context: Ctx) => boolean;
+  skip?: (context?: Ctx) => boolean;
 }
 
 export interface UrlOptions {
@@ -45,5 +45,5 @@ export interface ConnectOptions<Ctx> {
   urlOptions: UrlOptions;
   timeout: number | null;
   WebSocketClass?: typeof WebSocket;
-  context: Ctx;
+  context?: Ctx;
 }

--- a/src/util/helpers.ts
+++ b/src/util/helpers.ts
@@ -1,6 +1,4 @@
-/* global WebSocket */
 import { ConnectOptions } from '../types';
-import { EIOCompat } from './EIOCompat';
 
 const BACKOFF_FACTOR = 1.7;
 const MAX_BACKOFF = 15000;
@@ -25,10 +23,6 @@ function isWebSocket(w: unknown): w is WebSocket {
 }
 
 export function getWebSocketClass(options: ConnectOptions) {
-  if (options.polling) {
-    return EIOCompat;
-  }
-
   if (options.WebSocketClass) {
     if (!isWebSocket(options.WebSocketClass)) {
       throw new Error('Passed in WebSocket does not look like a standard WebSocket');
@@ -45,5 +39,5 @@ export function getWebSocketClass(options: ConnectOptions) {
     return WebSocket;
   }
 
-  throw new Error('Please pass in a WebSocket class, add it to global, or use the polling option');
+  throw new Error('Please pass in a WebSocket class or add it to global');
 }


### PR DESCRIPTION
Why
===
Right now context is passed to each `open` and `openChannel` calls. Typing like that works for most cases but you don't get any real type check guarantees. As it's unlikely for the shape of the context to change between `open` calls, we set the context on the client and let 


What changed
============
Ctx is now passed as a generic to `Client<{ username: string }>`. All calls now implicitly get the context.
Renamed generic from `D` to `Ctx`
`connectOptions` is now null until `open` is called

