### PR TITLE
Simplify channel API and make connecting and closing more robust

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-echo Add a repl token to use for tests:
-read token
+echo Add token secret for tests:
+read secret
 
-REPL_TOKEN=$token ./node_modules/.bin/jest --no-cache test $@
+TOKEN_SECRET=$secret ./node_modules/.bin/jest --no-cache test $@
 NODE_ENV="test"

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -55,23 +55,59 @@ function genToken() {
 jest.setTimeout(10 * 1000);
 
 test('client connect', (done) => {
-  const onUnrecoverableError = jest.fn<void, [Error]>();
-  const client = new Client();
-  client.setUnrecoverErrorHandler(onUnrecoverableError);
+  const client = new Client<{ username: string }>();
+  client.setUnrecoverErrorHandler(done);
+
+  const ctx = { username: 'zyzz' };
 
   client.open(
     {
-      fetchToken: () => Promise.resolve({ token: REPL_TOKEN, aborted: false }),
+      fetchToken: () => Promise.resolve({ token: genToken(), aborted: false }),
       WebSocketClass: WebSocket,
+      context: ctx,
     },
-    ({ channel, error }) => {
-      expect(channel?.closed).toBe(false);
+    ({ channel, error, context }) => {
+      expect(channel?.status).toBe('open');
+      expect(context).toBe(ctx);
       expect(error).toEqual(null);
 
-      setTimeout(() => client.close());
+      client.close();
 
       return () => {
-        expect(onUnrecoverableError).toHaveBeenCalledTimes(0);
+        done();
+      };
+    },
+  );
+});
+
+test('client retries', (done) => {
+  const client = new Client();
+  client.setUnrecoverErrorHandler(done);
+
+  let tryCount = 0;
+
+  client.open(
+    {
+      fetchToken: () => {
+        tryCount += 1;
+
+        if (tryCount === 1) {
+          return Promise.resolve({ token: 'test - bad token retries', aborted: false });
+        }
+
+        return Promise.resolve({ token: genToken(), aborted: false });
+      },
+      WebSocketClass: WebSocket,
+      context: null,
+    },
+    ({ channel, error }) => {
+      expect(tryCount).toBe(2);
+      expect(channel?.status).toBe('open');
+      expect(error).toEqual(null);
+
+      client.close();
+
+      return () => {
         done();
       };
     },
@@ -83,29 +119,29 @@ test('channel closing itself when client willReconnect', (done) => {
   let clientOpenCount = 0;
   let channelOpenCount = 0;
 
-  const onUnrecoverableError = jest.fn<void, [Error]>();
   const client = new Client();
-  client.setUnrecoverErrorHandler(onUnrecoverableError);
+  client.setUnrecoverErrorHandler(done);
 
   client.open(
     {
-      fetchToken: () => Promise.resolve({ token: REPL_TOKEN, aborted: false }),
+      fetchToken: () => Promise.resolve({ token: genToken(), aborted: false }),
       WebSocketClass: WebSocket,
+      context: null,
     },
     ({ channel, error }) => {
       clientOpenCount += 1;
-      expect(channel?.closed).toBe(false);
       expect(error).toEqual(null);
+      expect(channel?.status).toBe('open');
 
       if (!disconnectTriggered) {
         setTimeout(() => {
+          disconnectTriggered = true;
           // eslint-disable-next-line
           // @ts-ignore: trigger unintentional disconnect
-          client.ws?.onclose();
-          disconnectTriggered = true;
+          client.ws.close();
         }, 1000);
       } else {
-        setTimeout(() => client.close());
+        client.close();
       }
 
       return ({ willReconnect }) => {
@@ -116,7 +152,6 @@ test('channel closing itself when client willReconnect', (done) => {
         expect(clientOpenCount).toEqual(2);
         expect(channelOpenCount).toEqual(1);
 
-        expect(onUnrecoverableError).toHaveBeenCalledTimes(0);
         done();
       };
     },
@@ -124,10 +159,11 @@ test('channel closing itself when client willReconnect', (done) => {
 
   const close = client.openChannel({ service: 'shell' }, ({ channel, error }) => {
     channelOpenCount += 1;
-    expect(channel?.closed).toBe(false);
     expect(error).toBe(null);
+    expect(channel?.status).toBe('open');
 
-    return () => {
+    return ({ willReconnect }) => {
+      expect(willReconnect).toBeTruthy();
       // This cleanup function gets called because we triggered an unintentional
       // disconnect above (`client.ws.onclose()`). Since this is unintentional
       // the client will reconnect itself. But this outer `openChannel`callback will NOT
@@ -141,18 +177,19 @@ test('channel closing itself when client willReconnect', (done) => {
 test('channel open and close', (done) => {
   const onUnrecoverableError = jest.fn<void, [Error]>();
   const client = new Client();
-  client.setUnrecoverErrorHandler(onUnrecoverableError);
+  client.setUnrecoverErrorHandler(done);
 
   const channelClose = jest.fn();
 
   client.open(
     {
-      fetchToken: () => Promise.resolve({ token: REPL_TOKEN, aborted: false }),
+      fetchToken: () => Promise.resolve({ token: genToken(), aborted: false }),
       WebSocketClass: WebSocket,
+      context: null,
     },
     ({ channel, error }) => {
-      expect(channel?.closed).toBe(false);
       expect(error).toEqual(null);
+      expect(channel?.status).toBe('open');
 
       return () => {
         expect(channelClose).toHaveBeenCalled();
@@ -164,12 +201,17 @@ test('channel open and close', (done) => {
   );
 
   const close = client.openChannel({ service: 'shell' }, ({ channel, error }) => {
-    expect(channel?.closed).toBe(false);
+    expect(channel?.status).toBe('open');
     expect(error).toBe(null);
 
     close();
 
-    return () => {
+    expect(channel?.status).toBe('closing');
+
+    return ({ willReconnect }) => {
+      expect(willReconnect).toBeFalsy();
+      expect(channel?.status).toBe('closed');
+
       channelClose();
       client.close();
     };
@@ -177,63 +219,65 @@ test('channel open and close', (done) => {
 });
 
 test('channel skips opening', (done) => {
-  const onUnrecoverableError = jest.fn<void, [Error]>();
-  const client = new Client();
-  client.setUnrecoverErrorHandler(onUnrecoverableError);
+  const client = new Client<{ username: string }>();
+  client.setUnrecoverErrorHandler(done);
+
   const service = 'shell';
+  const ctx = { username: 'midas' };
+  const skipfn = jest.fn().mockImplementation(() => true);
+  const opencb = jest.fn();
 
   client.open(
     {
-      fetchToken: () => Promise.resolve({ token: REPL_TOKEN, aborted: false }),
+      fetchToken: () => Promise.resolve({ token: genToken(), aborted: false }),
       WebSocketClass: WebSocket,
+      context: ctx,
     },
     ({ error }) => {
       expect(error).toBeNull();
 
-      setTimeout(() => client.close());
+      setTimeout(() => {
+        expect(skipfn).toHaveBeenCalledTimes(1);
+        expect(skipfn).toHaveBeenCalledWith(ctx);
+        expect(opencb).not.toHaveBeenCalled();
+
+        client.close();
+      }, 0);
 
       return () => {
-        // eslint-disable-next-line
-        // @ts-ignore
-        const request = client.channelRequests.find((cr) => cr.options.service === service);
-
-        if (!request) {
-          throw new Error('Expected request');
-        }
-
-        // If currentChannel is null we didn't try to open a the channel
-        expect(request.currentChannel).toBeNull();
-
-        expect(onUnrecoverableError).toHaveBeenCalledTimes(0);
         done();
       };
     },
   );
 
-  client.openChannel({ service, skip: () => true }, () => {});
+  client.openChannel(
+    {
+      service,
+      skip: skipfn,
+    },
+    opencb,
+  );
 });
 
 test('channel skips opening conditionally', (done) => {
-  let disconnectTriggered = false;
+  let unexpectedDisconnectTriggered = false;
   let clientOpenCount = 0;
   let channelOpenCount = 0;
 
-  const onUnrecoverableError = jest.fn<void, [Error]>();
   const client = new Client();
-  client.setUnrecoverErrorHandler(onUnrecoverableError);
-  const service = 'shell';
+  client.setUnrecoverErrorHandler(done);
 
   client.open(
     {
-      fetchToken: () => Promise.resolve({ token: REPL_TOKEN, aborted: false }),
+      fetchToken: () => Promise.resolve({ token: genToken(), aborted: false }),
       WebSocketClass: WebSocket,
+      context: null,
     },
     ({ channel, error }) => {
       clientOpenCount += 1;
-      expect(channel?.closed).toBe(false);
+      expect(channel?.status).toBe('open');
       expect(error).toEqual(null);
-
-      if (disconnectTriggered) {
+      if (unexpectedDisconnectTriggered) {
         setTimeout(() => client.close());
       }
 
@@ -245,7 +289,6 @@ test('channel skips opening conditionally', (done) => {
         expect(clientOpenCount).toEqual(2);
         expect(channelOpenCount).toEqual(1);
 
-        expect(onUnrecoverableError).toHaveBeenCalledTimes(0);
         done();
       };
     },
@@ -254,76 +297,32 @@ test('channel skips opening conditionally', (done) => {
   client.openChannel(
     {
       skip: () => channelOpenCount > 0,
-      service,
+      service: 'shell',
     },
     ({ channel, error }) => {
-      if (!disconnectTriggered) {
+      if (!unexpectedDisconnectTriggered) {
         setTimeout(() => {
           // eslint-disable-next-line
           // @ts-ignore: trigger unintentional disconnect
-          client.ws?.onclose();
-          disconnectTriggered = true;
+          client.ws.close();
+          unexpectedDisconnectTriggered = true;
         }, 1000);
+
+        expect(error).toBe(null);
+        expect(channel?.status).toBe('open');
+
+        channelOpenCount += 1;
+
+        return;
       }
 
-      channelOpenCount += 1;
-      expect(channel?.closed).toBe(false);
-      expect(error).toBe(null);
-    },
-  );
-});
-
-// Test is broken right now due to polling fallback
-test.skip('client errors opening', (done) => {
-  const onUnrecoverableError = jest.fn<void, [Error]>();
-  const client = new Client();
-  client.setUnrecoverErrorHandler(onUnrecoverableError);
-  let errorCount = 0;
-
-  const clientClose = jest.fn();
-  const channelClose = jest.fn();
-
-  const maybeDone = () => {
-    if (errorCount === 2) {
-      // Close functions are not called when connect/openChannel return an error
-      // Any setup logic should be avoided
-      expect(clientClose).not.toHaveBeenCalled();
-      expect(channelClose).not.toHaveBeenCalled();
-
-      expect(onUnrecoverableError).toHaveBeenCalledTimes(0);
-      done();
-    }
-  };
-
-  client.open(
-    {
-      maxConnectRetries: 0,
-      fetchToken: () => Promise.resolve({ token: 'test - no good', aborted: false }),
-      WebSocketClass: WebSocket,
-    },
-    ({ channel, error }) => {
       expect(error).toBeTruthy();
-      expect(channel).toEqual(null);
-      errorCount += 1;
-
-      setTimeout(maybeDone);
-
-      return clientClose;
+      expect(error?.message).toBe('Failed to open');
     },
   );
-
-  client.openChannel({ service: 'shell' }, ({ channel, error }) => {
-    expect(error).toBeTruthy();
-    expect(channel).toEqual(null);
-    errorCount += 1;
-
-    setTimeout(maybeDone);
-
-    return channelClose;
-  });
 });
 
-test('client reconnect', (done) => {
+test('client reconnects unexpected disconnects', (done) => {
   const onUnrecoverableError = jest.fn<void, [Error]>();
   const client = new Client();
   client.setUnrecoverErrorHandler(onUnrecoverableError);
@@ -335,12 +334,13 @@ test('client reconnect', (done) => {
 
   client.open(
     {
-      fetchToken: () => Promise.resolve({ token: REPL_TOKEN, aborted: false }),
+      fetchToken: () => Promise.resolve({ token: genToken(), aborted: false }),
       WebSocketClass: WebSocket,
+      context: null,
     },
     ({ channel, error }) => {
       expect(error).toEqual(null);
-      expect(channel?.closed).toEqual(false);
+      expect(channel?.status).toEqual('open');
 
       timesConnected += 1;
 
@@ -348,11 +348,11 @@ test('client reconnect', (done) => {
         setTimeout(() => {
           // eslint-disable-next-line
           // @ts-ignore: trigger unintentional disconnect
-          client.ws?.onclose();
+          client.ws?.close();
           disconnectTriggered = true;
         });
       } else {
-        setTimeout(() => client.close());
+        client.close();
       }
 
       return (closeReason) => {
@@ -381,12 +381,11 @@ test('client reconnect', (done) => {
 test('client is closed while reconnecting', (done) => {
   let didOpen = false;
 
-  const open = jest.fn();
-  const close = jest.fn();
+  const onOpen = jest.fn();
+  const onClose = jest.fn();
 
-  const onUnrecoverableError = jest.fn<void, [Error]>();
   const client = new Client();
-  client.setUnrecoverErrorHandler(onUnrecoverableError);
+  client.setUnrecoverErrorHandler(done);
   const fetchToken = () => {
     if (didOpen) {
       // We're reconnecting
@@ -394,49 +393,46 @@ test('client is closed while reconnecting', (done) => {
         // Close client while reconnecting
         client.close();
 
-        expect(open).toHaveBeenCalledTimes(1);
-        expect(close).toHaveBeenCalledTimes(1);
+        expect(onOpen).toHaveBeenCalledTimes(1);
+        expect(onClose).toHaveBeenCalledTimes(1);
 
-        expect(onUnrecoverableError).toHaveBeenCalledTimes(0);
         done();
       });
     }
 
-    return Promise.resolve({ token: REPL_TOKEN, aborted: false });
+    return Promise.resolve({ token: genToken(), aborted: false });
   };
 
   client.open(
     {
-      // eslint-disable-next-line @typescript-eslint/no-use-before-define
       fetchToken,
       WebSocketClass: WebSocket,
+      context: null,
     },
     ({ channel }) => {
       if (channel) {
         // called once after initial connect
-        open();
+        onOpen();
 
         didOpen = true;
 
         setTimeout(() => {
           // eslint-disable-next-line
           // @ts-ignore: trigger unintentional disconnect
-          client.ws?.onclose();
+          client.ws?.close();
         });
       }
 
       return () => {
         // called once after dissconnect
-        close();
+        onClose();
       };
     },
   );
 });
 
-test('closing before ever connecting', () => {
-  const onUnrecoverableError = jest.fn<void, [Error]>();
+test('closing before ever connecting', (done) => {
   const client = new Client();
-  client.setUnrecoverErrorHandler(onUnrecoverableError);
 
   const open = jest.fn();
   const openError = jest.fn();
@@ -444,12 +440,24 @@ test('closing before ever connecting', () => {
 
   client.open(
     {
-      fetchToken: () => Promise.resolve({ token: REPL_TOKEN, aborted: false }),
+      fetchToken: () => {
+        setTimeout(() => {
+          // `close` called before connecting
+          client.close();
+        }, 0);
+
+        return Promise.resolve({ token: genToken(), aborted: false });
+      },
       WebSocketClass: WebSocket,
+      context: null,
     },
     ({ error }) => {
       if (error) {
         openError();
+        expect(open).not.toHaveBeenCalled();
+        expect(openError).toHaveBeenCalledTimes(1);
+        expect(close).not.toHaveBeenCalled();
+        done();
       } else {
         open();
       }
@@ -459,119 +467,49 @@ test('closing before ever connecting', () => {
       };
     },
   );
-
-  // `close` called before connecting
-  client.close();
-
-  expect(open).not.toHaveBeenCalled();
-  expect(openError).toHaveBeenCalledTimes(1);
-  expect(close).not.toHaveBeenCalled();
 });
 
-test('closing client while opening', (done) => {
-  const onUnrecoverableError = jest.fn<void, [Error]>();
-  const client = new Client();
-  client.setUnrecoverErrorHandler(onUnrecoverableError);
+// // re-add once we add polling
+// test.skip('falling back to polling', (done) => {
+//   const onUnrecoverableError = jest.fn<void, [Error]>();
+//   const client = new Client();
+//   client.setUnrecoverErrorHandler(onUnrecoverableError);
 
-  client.open(
-    {
-      fetchToken: () => Promise.resolve({ token: REPL_TOKEN, aborted: false }),
-      WebSocketClass: WebSocket,
-    },
-    () => {
-      try {
-        client.close();
-      } catch {
-        expect(onUnrecoverableError).toHaveBeenCalledTimes(0);
-        done();
-      }
-    },
-  );
-});
+//   const maxConnectRetries = 1;
+//   const open = jest.fn();
 
-test('connecting with a context object', (done) => {
-  const onUnrecoverableError = jest.fn<void, [Error]>();
-  const client = new Client();
-  client.setUnrecoverErrorHandler(onUnrecoverableError);
-  const user = 'abc';
+//   client.setDebugFunc((log) => {
+//     if (log.type === 'breadcrumb' && log.message === 'falling back to polling') {
+//       // eslint-disable-next-line
+//       const data = log.data as any;
 
-  client.open<{ user: string }>(
-    {
-      fetchToken: () => Promise.resolve({ token: REPL_TOKEN, aborted: false }),
-      WebSocketClass: WebSocket,
-      context: { user },
-    },
-    ({ context }) => {
-      expect(context).toEqual({ user });
-    },
-  );
+//       expect(data.connectTries).toEqual(maxConnectRetries + 1);
+//       expect(data.error).toBeDefined();
+//       expect(data.wsReadyState).toBeUndefined();
 
-  client.openChannel<{ user: string }>(
-    {
-      service: 'shell',
-      skip: (context) => {
-        expect(context).toEqual({ user });
+//       // eslint-disable-next-line
+//       // @ts-ignore need to reach in and grab some private fields real quick...
+//       const { urlOptions, polling } = client.connectOptions;
 
-        return false;
-      },
-    },
-    ({ error, context }) => {
-      expect(context).toEqual({ user });
+//       expect(urlOptions.host).toEqual('gp-v2.herokuapp.com');
+//       expect(polling).toBe(true);
 
-      if (error) {
-        // Client closed so test is done.
+//       expect(open).not.toHaveBeenCalled();
 
-        expect(onUnrecoverableError).toHaveBeenCalledTimes(0);
-        done();
-        return;
-      }
+//       expect(onUnrecoverableError).toHaveBeenCalledTimes(0);
+//       done();
+//     }
+//   });
 
-      client.close();
-    },
-  );
-});
-
-// re-add once we add polling
-test.skip('falling back to polling', (done) => {
-  const onUnrecoverableError = jest.fn<void, [Error]>();
-  const client = new Client();
-  client.setUnrecoverErrorHandler(onUnrecoverableError);
-
-  const maxConnectRetries = 1;
-  const open = jest.fn();
-
-  client.setDebugFunc((log) => {
-    if (log.type === 'breadcrumb' && log.message === 'falling back to polling') {
-      // eslint-disable-next-line
-      const data = log.data as any;
-
-      expect(data.connectTries).toEqual(maxConnectRetries + 1);
-      expect(data.error).toBeDefined();
-      expect(data.wsReadyState).toBeUndefined();
-
-      // eslint-disable-next-line
-      // @ts-ignore need to reach in and grab some private fields real quick...
-      const { urlOptions, polling } = client.connectOptions;
-
-      expect(urlOptions.host).toEqual('gp-v2.herokuapp.com');
-      expect(polling).toBe(true);
-
-      expect(open).not.toHaveBeenCalled();
-
-      expect(onUnrecoverableError).toHaveBeenCalledTimes(0);
-      done();
-    }
-  });
-
-  client.open(
-    {
-      fetchToken: () => Promise.resolve({ token: 'bad token', aborted: false }),
-      WebSocketClass: WebSocket,
-      timeout: 0,
-    },
-    open,
-  );
-});
+//   client.open(
+//     {
+//       fetchToken: () => Promise.resolve({ token: 'bad token', aborted: false }),
+//       WebSocketClass: WebSocket,
+//       timeout: 0,
+//     },
+//     open,
+//   );
+// });
 
 test('fetch token fail', (done) => {
   const chan0Cb = jest.fn();
@@ -590,6 +528,7 @@ test('fetch token fail', (done) => {
         throw new Error('fail');
       },
       WebSocketClass: WebSocket,
+      context: null,
     },
     chan0Cb,
   );
@@ -621,11 +560,12 @@ test('fetch abort signal works as expected', (done) => {
           }, 0);
         }),
       WebSocketClass: WebSocket,
+      context: null,
     },
     ({ channel, error }) => {
       expect(channel).toBe(null);
       expect(error).toBeTruthy();
-      expect(error?.message).toBe('Channel closed');
+      expect(error?.message).toBe('Failed to open');
       expect(onAbort).toHaveBeenCalledTimes(1);
 
       done();

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -56,7 +56,7 @@ jest.setTimeout(10 * 1000);
 
 test('client connect', (done) => {
   const client = new Client<{ username: string }>();
-  client.setUnrecoverErrorHandler(done);
+  client.setUnrecoverableErrorHandler(done);
 
   const ctx = { username: 'zyzz' };
 
@@ -82,7 +82,7 @@ test('client connect', (done) => {
 
 test('client retries', (done) => {
   const client = new Client();
-  client.setUnrecoverErrorHandler(done);
+  client.setUnrecoverableErrorHandler(done);
 
   let tryCount = 0;
 
@@ -120,7 +120,7 @@ test('channel closing itself when client willReconnect', (done) => {
   let channelOpenCount = 0;
 
   const client = new Client();
-  client.setUnrecoverErrorHandler(done);
+  client.setUnrecoverableErrorHandler(done);
 
   client.open(
     {
@@ -177,7 +177,7 @@ test('channel closing itself when client willReconnect', (done) => {
 test('channel open and close', (done) => {
   const onUnrecoverableError = jest.fn<void, [Error]>();
   const client = new Client();
-  client.setUnrecoverErrorHandler(done);
+  client.setUnrecoverableErrorHandler(done);
 
   const channelClose = jest.fn();
 
@@ -220,7 +220,7 @@ test('channel open and close', (done) => {
 
 test('channel skips opening', (done) => {
   const client = new Client<{ username: string }>();
-  client.setUnrecoverErrorHandler(done);
+  client.setUnrecoverableErrorHandler(done);
 
   const service = 'shell';
   const ctx = { username: 'midas' };
@@ -265,7 +265,7 @@ test('channel skips opening conditionally', (done) => {
   let channelOpenCount = 0;
 
   const client = new Client();
-  client.setUnrecoverErrorHandler(done);
+  client.setUnrecoverableErrorHandler(done);
 
   client.open(
     {
@@ -325,7 +325,7 @@ test('channel skips opening conditionally', (done) => {
 test('client reconnects unexpected disconnects', (done) => {
   const onUnrecoverableError = jest.fn<void, [Error]>();
   const client = new Client();
-  client.setUnrecoverErrorHandler(onUnrecoverableError);
+  client.setUnrecoverableErrorHandler(onUnrecoverableError);
 
   let disconnectTriggered = false;
   let timesConnected = 0;
@@ -385,7 +385,7 @@ test('client is closed while reconnecting', (done) => {
   const onClose = jest.fn();
 
   const client = new Client();
-  client.setUnrecoverErrorHandler(done);
+  client.setUnrecoverableErrorHandler(done);
   const fetchToken = () => {
     if (didOpen) {
       // We're reconnecting
@@ -515,7 +515,7 @@ test('fetch token fail', (done) => {
   const chan0Cb = jest.fn();
   const client = new Client();
 
-  client.setUnrecoverErrorHandler((e) => {
+  client.setUnrecoverableErrorHandler((e) => {
     expect(chan0Cb).toHaveBeenCalledTimes(1);
     expect(e.message).toContain('fail');
 
@@ -536,7 +536,7 @@ test('fetch token fail', (done) => {
 
 test('fetch abort signal works as expected', (done) => {
   const client = new Client();
-  client.setUnrecoverErrorHandler(() => {
+  client.setUnrecoverableErrorHandler(() => {
     done(new Error('did not expect fatal to be called'));
   });
 

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1,14 +1,55 @@
 /* eslint-env jest */
 
+import * as crypto from 'crypto';
 import { Client } from '..';
 
 // eslint-disable-next-line
 const WebSocket = require('ws');
 
-const REPL_TOKEN = process.env.REPL_TOKEN as string;
+const TOKEN_SECRET = process.env.TOKEN_SECRET as string;
 
-if (!REPL_TOKEN) {
-  throw new Error('REPL_TOKEN is required');
+if (!TOKEN_SECRET) {
+  throw new Error('TOKEN_SECRET is required to run tests');
+}
+
+function genToken() {
+  const opts = {
+    id: `testing-crosis-${Math.random().toString(36).split('.')[1]}`,
+    mem: 1024 * 1024 * 512,
+    thread: 0.5,
+    share: 0.5,
+    net: true,
+    attach: true,
+    bucket: 'test-replit-repls',
+    ephemeral: true,
+    nostore: true,
+    language: 'bash',
+    owner: true,
+    path: Math.random().toString(36).split('.')[1],
+    disk: 1024 * 1024 * 1024,
+    bearerName: 'crosistest',
+    bearerId: 2,
+    presenced: true,
+    user: 'crosistest',
+    pullFiles: true,
+    polygott: false,
+    format: 'pbuf',
+  };
+  const encodedOpts = Buffer.from(
+    JSON.stringify({
+      created: Date.now(),
+      salt: Math.random().toString(36).split('.')[1],
+      ...opts,
+    }),
+  ).toString('base64');
+
+  const hmac = crypto.createHmac('sha256', TOKEN_SECRET);
+  hmac.update(encodedOpts);
+  const msgMac = hmac.digest('base64');
+
+  const token = Buffer.from(`${encodedOpts}:${msgMac}`);
+
+  return token.toString('base64');
 }
 
 jest.setTimeout(10 * 1000);

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -88,7 +88,9 @@ export class Channel {
 
     this.onCommandListeners.push(listener);
 
-    return () => this.onCommandListeners.filter((l) => l !== listener);
+    return () => {
+      this.onCommandListeners = this.onCommandListeners.filter((l) => l !== listener);
+    };
   };
 
   /**

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -43,10 +43,6 @@ export class Channel {
 
   public status: 'open' | 'closed' | 'closing';
 
-  public name: string | void;
-
-  public service: string;
-
   private sendToClient: (cmd: api.Command) => void;
 
   private requestMap: { [ref: string]: (res: RequestResult) => void };
@@ -57,20 +53,14 @@ export class Channel {
 
   constructor({
     id,
-    name,
-    service,
     send,
     onUnrecoverableError,
   }: {
     id: number;
-    name: string | void;
-    service: string;
     send: (cmd: api.Command) => void;
     onUnrecoverableError: (e: Error) => void;
   }) {
     this.id = id;
-    this.name = name;
-    this.service = service;
     this.sendToClient = send;
     this.onUnrecoverableError = onUnrecoverableError;
     this.status = 'open';
@@ -152,6 +142,7 @@ export class Channel {
    * @hidden should only be called by [[Client]]
    *
    * Called when the channel or client is closed
+
    * concludes all the requests promises and cleans up
    * the onCommand listeners
    */

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -117,10 +117,15 @@ export class Channel {
     const ref = Number(Math.random().toString().split('.')[1]).toString(36);
     cmdJson.ref = ref;
 
-    return new Promise((resolve) => {
+    return new Promise((resolve, reject) => {
       this.requestMap[ref] = resolve;
 
-      this.send(cmdJson);
+      try {
+        this.send(cmdJson);
+      } catch (e) {
+        delete this.requestMap[ref];
+        reject(e);
+      }
     });
   };
 

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1,8 +1,7 @@
-import { EventEmitter } from 'events';
 import { api } from '@replit/protocol';
 import { ChannelCloseReason } from './types';
 
-export interface RequestResult extends api.Command {
+interface RequestResult extends api.Command {
   channelClosed?: ChannelCloseReason;
 }
 
@@ -38,51 +37,49 @@ export interface RequestResult extends api.Command {
  * closeChannel() // Will call potential returned cleanup function
  *
  */
-export type OpenChannelCb<Ctx> = (res: OpenChannelRes<Ctx>) => void | OnCloseFn;
 
-type OnCloseFn = (reason: ChannelCloseReason) => void;
+export class Channel {
+  public id: number;
 
-export type OpenChannelRes<Ctx> =
-  | { error: null; channel: Channel<Ctx>; context: Ctx }
-  | { error: Error; channel: null; context: Ctx };
+  public status: 'open' | 'closed' | 'closing';
 
-export class Channel<Ctx> {
-  public state: api.OpenChannelRes.State.CREATED | api.OpenChannelRes.State.ATTACHED | null;
+  public name: string | void;
 
-  public id: number | null;
+  public service: string;
 
-  public closed: boolean;
-
-  private sendToClient: ((cmd: api.Command) => void) | null;
+  private sendToClient: (cmd: api.Command) => void;
 
   private requestMap: { [ref: string]: (res: RequestResult) => void };
 
-  private openChannelCb: OpenChannelCb<Ctx>;
-
   private onCommandListeners: Array<(cmd: api.Command) => void>;
-
-  private openChannelCbClose: ReturnType<OpenChannelCb<Ctx>> | null;
 
   private onUnrecoverableError: (e: Error) => void;
 
-  constructor(
-    config: { openChannelCb: OpenChannelCb<Ctx> },
-    onUnrecoverableError: (e: Error) => void,
-  ) {
-    this.id = null;
-    this.sendToClient = null;
-    this.state = null;
-    this.closed = false;
-    this.requestMap = {};
-    this.openChannelCb = config.openChannelCb;
-    this.openChannelCbClose = null;
-    this.emitter = new EventEmitter();
+  constructor({
+    id,
+    name,
+    service,
+    send,
+    onUnrecoverableError,
+  }: {
+    id: number;
+    name: string | void;
+    service: string;
+    send: (cmd: api.Command) => void;
+    onUnrecoverableError: (e: Error) => void;
+  }) {
+    this.id = id;
+    this.name = name;
+    this.service = service;
+    this.sendToClient = send;
     this.onUnrecoverableError = onUnrecoverableError;
+    this.status = 'open';
+    this.requestMap = {};
     this.onCommandListeners = [];
   }
 
   public onCommand = (listener: (cmd: api.Command) => void) => {
-    if (this.closed) {
+    if (this.status === 'closed') {
       const e = new Error('Trying to listen to commands on a closed channel');
       this.onUnrecoverableError(e);
 
@@ -95,54 +92,20 @@ export class Channel<Ctx> {
   };
 
   /**
-   * Closes the channel
-   *
-   * see http://protodoc.turbio.repl.co/protov2#closing-channels
-   * @param action [[api.OpenChannel.Action]] specifies how you want to close the channel
-   */
-  public close = (action: api.CloseChannel.Action = api.CloseChannel.Action.TRY_CLOSE) => {
-    if (this.closed === true) {
-      const e = new Error('Channel already closed');
-      this.onUnrecoverableError(e);
-
-      throw e;
-    }
-
-    const cmd = api.Command.create({
-      channel: 0,
-      closeChan: {
-        action,
-        id: this.id,
-      },
-    });
-
-    if (!this.sendToClient) {
-      const e = new Error('Expected sendToClient');
-      this.onUnrecoverableError(e);
-
-      throw e;
-    }
-
-    // Send close command to chan0
-    this.sendToClient(cmd);
-    this.closed = true;
-  };
-
-  /**
    * Receives a command and sends it over the wire
    * along with the channel id.
    * @param cmdJson shape of a command see [[api.ICommand]]
    */
   public send = (cmdJson: api.ICommand) => {
-    if (!this.sendToClient) {
-      const e = new Error('Sending on a channel that never opened');
+    if (this.status === 'closed') {
+      const e = new Error('Calling send on closed channel');
       this.onUnrecoverableError(e);
 
       throw e;
     }
 
-    if (this.closed) {
-      const e = new Error('Calling send on closed channel');
+    if (this.status === 'closing') {
+      const e = new Error('Cannot send any more commands after a close request');
       this.onUnrecoverableError(e);
 
       throw e;
@@ -158,13 +121,6 @@ export class Channel<Ctx> {
    * @param cmdJson shape of a command see [[api.ICommand]]
    */
   public request = async (cmdJson: api.ICommand): Promise<RequestResult> => {
-    if (this.closed) {
-      const e = new Error('Calling request on closed channel');
-      this.onUnrecoverableError(e);
-
-      throw e;
-    }
-
     // Random base36 int
     const ref = Number(Math.random().toString().split('.')[1]).toString(36);
     cmdJson.ref = ref;
@@ -179,39 +135,9 @@ export class Channel<Ctx> {
   /**
    * @hidden should only be called by [[Client]]
    *
-   * Called when the channel opens
-   */
-  public handleOpenRes = ({
-    id,
-    state,
-    send,
-    context,
-  }: {
-    id: number;
-    state: api.OpenChannelRes.State.CREATED | api.OpenChannelRes.State.ATTACHED;
-    send: (cmd: api.Command) => void;
-    context: Ctx;
-  }) => {
-    this.id = id;
-    this.sendToClient = send;
-    this.state = state;
-
-    this.openChannelCbClose = this.openChannelCb({ channel: this, error: null, context });
-  };
-
-  /**
-   * @hidden should only be called by [[Client]]
-   *
    * Called when the channel recieves a message
    */
   public handleCommand = (cmd: api.Command) => {
-    if (this.closed) {
-      // Ignore commands coming in after close.
-      // this can happen if we requested a close and there are
-      // still commands that are processed before our close request
-      return;
-    }
-
     this.onCommandListeners.forEach((l) => l(cmd));
 
     if (cmd.ref && this.requestMap[cmd.ref]) {
@@ -224,8 +150,10 @@ export class Channel<Ctx> {
    * @hidden should only be called by [[Client]]
    *
    * Called when the channel or client is closed
+   * concludes all the requests promises and cleans up
+   * the onCommand listeners
    */
-  public handleClose = (reason: ChannelCloseReason, context: Ctx) => {
+  public handleClose = (reason: ChannelCloseReason) => {
     Object.keys(this.requestMap).forEach((ref) => {
       const requestResult = api.Command.fromObject({}) as RequestResult;
       requestResult.channelClosed = reason;
@@ -233,49 +161,7 @@ export class Channel<Ctx> {
       delete this.requestMap[ref];
     });
 
-    if (reason.initiator === 'channel' && !this.closed) {
-      const e = new Error('Expected channel to be marked as closed when the initiator is channel');
-      this.onUnrecoverableError(e);
-      // Do some cleanup regardless
-      this.closed = true;
-      this.emitter.removeAllListeners();
-
-      throw e;
-    }
-
-    if (reason.initiator === 'channel' && !this.openChannelCbClose) {
-      const e = new Error(
-        'Expected openChannelCbClose to be truthy when the close intiator is the channel',
-      );
-      this.onUnrecoverableError(e);
-      // Do some cleanup regardless
-      this.closed = true;
-      this.emitter.removeAllListeners();
-
-      return;
-    }
-
-    if (this.openChannelCbClose) {
-      // The channel opened previously and we need to send the close reason
-      // to the close callback supplied to us by the user
-      this.openChannelCbClose(reason);
-      this.openChannelCbClose = null;
-
-      return;
-    }
-
-    if (reason.willReconnect) {
-      // We never got to open a channel, and we will reconnect
-      // no need to do anything as we never the open callback
-      return;
-    }
-
-    // We never opened the channel and we will never open
-    // report to the openChannelCb
-    this.openChannelCb({
-      error: new Error('Failed to open'),
-      channel: null,
-      context,
-    });
+    this.status = 'closed';
+    this.onCommandListeners = [];
   };
 }

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -54,7 +54,7 @@ export class Channel {
   /**
    * Sends the command to the container
    */
-  private sendToClient: (cmd: api.Command) => void;
+  private sendToContainer: (cmd: api.Command) => void;
 
   /**
    * A map of request reference id to resolver function generated
@@ -87,7 +87,7 @@ export class Channel {
     onUnrecoverableError: (e: Error) => void;
   }) {
     this.id = id;
-    this.sendToClient = send;
+    this.sendToContainer = send;
     this.onUnrecoverableError = onUnrecoverableError;
     this.status = 'open';
     this.requestMap = {};
@@ -136,7 +136,7 @@ export class Channel {
     }
 
     cmdJson.channel = this.id;
-    this.sendToClient(api.Command.create(cmdJson));
+    this.sendToContainer(api.Command.create(cmdJson));
   };
 
   /**

--- a/src/client.ts
+++ b/src/client.ts
@@ -157,6 +157,10 @@ export class Client<Ctx extends unknown = null> {
    * http://protodoc.turbio.repl.co/protov2#opening-channels
    */
   public openChannel = (options: ChannelOptions<Ctx>, cb: OpenChannelCb<Ctx>) => {
+    if (!this.chan0Cb) {
+      throw new Error('You must call client.open before attempting to open any channels');
+    }
+
     const channelRequest: ChannelRequest<Ctx> = {
       options,
       openChannelCb: cb,

--- a/src/client.ts
+++ b/src/client.ts
@@ -325,8 +325,6 @@ export class Client<Ctx extends unknown = null> {
 
       const channel = new Channel({
         id,
-        name: options.name,
-        service: options.service,
         onUnrecoverableError: this.onUnrecoverableError,
         send: this.send,
       });
@@ -535,8 +533,6 @@ export class Client<Ctx extends unknown = null> {
 
     const chan0 = new Channel({
       id: 0,
-      name: '0',
-      service: '0',
       onUnrecoverableError: this.onUnrecoverableError,
       send: this.send,
     });

--- a/src/client.ts
+++ b/src/client.ts
@@ -533,7 +533,7 @@ export class Client<Ctx extends unknown = null> {
    * Unrecoverable errors are internal errors or invariance errors
    * caused by the user mis-using the client.
    */
-  public setUnrecoverErrorHandler(onUnrecoverableError: (e: Error) => void) {
+  public setUnrecoverableErrorHandler(onUnrecoverableError: (e: Error) => void) {
     this.userUnrecoverableErrorHandler = onUnrecoverableError;
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,4 +3,4 @@ import './util/utf8ReadMonkeypatch'; // pbjs's utf8 decoder is borked
 
 export { Client } from './client';
 export { Channel } from './channel';
-export { ChannelCloseReason, ChannelOptions } from './types';
+export { ChannelCloseReason, ChannelOptions, ClientCloseReason } from './types';

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,5 +2,5 @@ import 'abortcontroller-polyfill/dist/abortcontroller-polyfill-only';
 import './util/utf8ReadMonkeypatch'; // pbjs's utf8 decoder is borked
 
 export { Client } from './client';
-export { Channel, OpenChannelCb } from './channel';
+export { Channel } from './channel';
 export { ChannelCloseReason, ChannelOptions } from './types';

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,15 +4,15 @@ export enum ClientCloseReason {
   /**
    * called `client.close`
    */
-  Intentional,
+  Intentional = 'Intentional',
   /**
    * The websocket connection died
    */
-  Disconnected,
+  Disconnected = 'Disconnected',
   /**
    * The client encountered an unrecoverable/invariant error
    */
-  Error,
+  Error = 'Error',
 }
 
 // Channel close can either be due to client closing

--- a/src/util/helpers.ts
+++ b/src/util/helpers.ts
@@ -22,7 +22,7 @@ function isWebSocket(w: unknown): w is WebSocket {
   return 'OPEN' in w && (w as WebSocket).OPEN === 1;
 }
 
-export function getWebSocketClass(options: ConnectOptions) {
+export function getWebSocketClass(options: ConnectOptions<unknown>) {
   if (options.WebSocketClass) {
     if (!isWebSocket(options.WebSocketClass)) {
       throw new Error('Passed in WebSocket does not look like a standard WebSocket');

--- a/src/util/helpers.ts
+++ b/src/util/helpers.ts
@@ -1,8 +1,11 @@
-import { ConnectOptions } from '../types';
+import { ConnectOptions, UrlOptions } from '../types';
 
 const BACKOFF_FACTOR = 1.7;
 const MAX_BACKOFF = 15000;
 
+/**
+ * Calculates the backoff for n retry
+ */
 export function getNextRetryDelay(retryNumber: number) {
   const randomMs = Math.floor(Math.random() * 500);
   const backoff = BACKOFF_FACTOR ** retryNumber * 1000;
@@ -22,6 +25,9 @@ function isWebSocket(w: unknown): w is WebSocket {
   return 'OPEN' in w && (w as WebSocket).OPEN === 1;
 }
 
+/**
+ * Gets a websocket class from the global scope, or asserts if the supplied websocket follows the standard
+ */
 export function getWebSocketClass(options: ConnectOptions<unknown>) {
   if (options.WebSocketClass) {
     if (!isWebSocket(options.WebSocketClass)) {
@@ -40,4 +46,13 @@ export function getWebSocketClass(options: ConnectOptions<unknown>) {
   }
 
   throw new Error('Please pass in a WebSocket class or add it to global');
+}
+
+/**
+ * Given a token and the URL options, creates a websocket connection string
+ */
+export function getConnectionStr(token: string, urlOptions: UrlOptions) {
+  const { secure, host, port } = urlOptions;
+
+  return `ws${secure ? 's' : ''}://${host}:${port}/wsv2/${token}`;
 }


### PR DESCRIPTION
Why
===
The channel being responsible for closing adds a lot of complexity to the code. On the surface it looks like it simplifies the client but in reality it makes it harder to deal with and reason about closing and reconnecting. The channel also had unnecessary APIs that made the code harder and the closing API inconsistent.

There were a few bugs that (tests reflect those) caused opening, connecting, retrying and closing to go out of sync. The origin of those bugs is due to the fact that the channel 0 closing relied on the internals of the channel which was hard to keep track of.

Because of how things are intertwind right now this PR had to be larger than I'd liked.

What changed
============
On a higher level:
- Reduced the API surface area of channels
- Moved all channel opening and closing logic to the client
- Sprinkled asserts all over the place
- Documented internals more clearly

API changes:
- `channel.close` is no longer a thing. You can only close using the return function from `client.openChannel`
- Removed a bunch of unused public instance variables on channels
- Channel now has a status rather than `closed` boolean indicating the different states it can be in `open` | `closed` | `closing`
  - Changed asserts to use that status instead
- Channels can still receive commands after calling close, until the channel is actually closed (or the connection is closed)
- `openChannel` cannot be called before `open`
- `client.close` can be called at any time without errors and closes predictibly

**channel internals**
- Removed event emitter in favor of simple callback array
  - In turn, removed setMaxListeners and getMaxListeners
- Channels are not responsible for opening and closing, we still have a `handleClose` function called by the client to cleanup internals and set state

**client internals**
- A lot more asserts for state invariance
- Channel requests now can be in 2 states with a discriminant `isOpen`
- Channel requests are used for opening and closing and has the relevant information for that
- Channels are properly closed regardless of when the close request is sent. In the past we can end up in a nasty place if it's called while openning is inflight.
- Channels are now only created after we open the channel. Previously we put currentChannel on the request before actually opening
- Now that channels are not responsible for opening and closing, we now store the cleanup cb returned from `chan0Cb` and call it when necessary inside the client
