### PR TITLE
[RFC] Allow client to re-use a websocket

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -651,7 +651,7 @@ test('fetch abort signal works as expected', (done) => {
   );
 });
 
-test.only('client multiplexed', (done) => {
+test('client multiplexed', (done) => {
   const wsSourceClient = new Client();
   const clientMultiplexed = new Client();
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,10 +40,28 @@ export interface UrlOptions {
   port: string;
 }
 
-export interface ConnectOptions<Ctx> {
+interface ConnectOptionsWithToken<Ctx> {
+  withPreconnectedSocket: false,
   fetchToken: (abortSignal: AbortSignal) => Promise<{ token: null, aborted: true } | { token: string, aborted: false }>;
+  context: Ctx;
   urlOptions: UrlOptions;
   timeout: number | null;
   WebSocketClass?: typeof WebSocket;
+}
+
+interface ConnectOptionsWithSocket<Ctx> {
+  withPreconnectedSocket: true,
+  getSocket: (abortSignal: AbortSignal) => Promise<{ ws: null, aborted: true } | { ws: WebSocket, aborted: false }>;
   context: Ctx;
 }
+
+export type ConnectOptions<Ctx> = ConnectOptionsWithSocket<Ctx> | ConnectOptionsWithToken<Ctx>;
+
+
+interface ConnectArgsWithToken<Ctx> extends Partial<ConnectOptionsWithToken<Ctx>> {
+  context: Ctx,
+  withPreconnectedSocket: false,
+  fetchToken: (abortSignal: AbortSignal) => Promise<{ token: null, aborted: true } | { token: string, aborted: false }>;
+}
+
+export type ConnectArgs<Ctx> = ConnectOptionsWithSocket<Ctx> | ConnectArgsWithToken<Ctx>

--- a/src/util/helpers.ts
+++ b/src/util/helpers.ts
@@ -29,6 +29,10 @@ function isWebSocket(w: unknown): w is WebSocket {
  * Gets a websocket class from the global scope, or asserts if the supplied websocket follows the standard
  */
 export function getWebSocketClass(options: ConnectOptions<unknown>) {
+  if (options.withPreconnectedSocket) {
+    throw new Error('Did not expected to be called with withPreconnectedSocket');
+  }
+
   if (options.WebSocketClass) {
     if (!isWebSocket(options.WebSocketClass)) {
       throw new Error('Passed in WebSocket does not look like a standard WebSocket');


### PR DESCRIPTION
Why
===
We're currently in a place where we wanna rollout v6. Rolling out 2 websockets lead to some issues, such as having to request captcha more than once to get a token, increase load on the backend, 2x sessions per user, out of sync opening and closing of clients...etc

What changed
============
Added a new option to `open` args which is `getSocket`. It expects a promise that returns a websocket and that will be used to communicate with goval.

Test plan
=========
I wrote a simple test case, seems to work. I also tried to do it by using a socket provided by v6