### PR TITLE
Maintain openChannel requests when the client closes

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -356,6 +356,50 @@ test('client rejects opening channel after closing client', () => {
   expect(errorHandler).toHaveBeenCalledTimes(0);
 });
 
+
+test('closing maintains openChannel requests', (done) => {
+  const client = new Client();
+  client.setUnrecoverableErrorHandler(done);
+
+  let first = true;
+  client.openChannel({ service: 'exec' }, ({ channel }) => {
+    expect(channel).toBeTruthy();
+
+    if (first) {
+      client.close();
+      first = false;
+
+      setTimeout(() => {
+        // open again should call this same function
+        client.open(
+          {
+            fetchToken: () => Promise.resolve({ token: genToken(), aborted: false }),
+            WebSocketClass: WebSocket,
+            context: null,
+          },
+          () => {},
+        );
+      }, 200);
+    } else {
+      client.close();
+      done();
+    }
+  });
+
+  client.open(
+    {
+      fetchToken: () => Promise.resolve({ token: genToken(), aborted: false }),
+      WebSocketClass: WebSocket,
+      context: null,
+    },
+    ({ channel }) => {
+      expect(channel).toBeTruthy();
+
+      return () => {};
+    },
+  );
+});
+
 test('client rejects opening same channel twice', (done) => {
   const client = new Client();
   client.setUnrecoverableErrorHandler(done);

--- a/src/client.ts
+++ b/src/client.ts
@@ -475,9 +475,13 @@ export class Client<Ctx extends unknown = null> {
 
   /**
    * Closes the connection.
-   * - If `open` was called but we didn't connect yet treat it as a connection error
+   * - `open` must have been called before calling this method
+   * - If we haven't connected yet, open callback will be called with an error
    * - If there's an open WebSocket connection it will be closed
-   * - Any open channels or channel requests are closed
+   * - Any open channels will be closed
+   *   - Does not clear openChannel requests
+   *   - If a channel never opened, its openChannel callback will be called with an error
+   *   - Otherwise returned cleanup callback is called
    */
   public close = () => {
     this.debug({ type: 'breadcrumb', message: 'user close' });

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,12 +1,7 @@
 import { api } from '@replit/protocol';
 import { Channel } from './channel';
 import { getWebSocketClass, getNextRetryDelay, getConnectionStr } from './util/helpers';
-import {
-  ConnectOptions,
-  ClientCloseReason,
-  ChannelCloseReason,
-  ChannelOptions,
-} from './types';
+import { ConnectOptions, ClientCloseReason, ChannelCloseReason, ChannelOptions } from './types';
 
 /**
  * The only required option is `fetchToken`, all others are optional and will use defaults
@@ -1001,12 +996,6 @@ export class Client<Ctx extends unknown = null> {
 
     this.channelRequests.forEach((channelRequest) => {
       const willChannelReconnect: boolean = willClientReconnect && !channelRequest.closeRequested;
-
-      if (!willChannelReconnect) {
-        // If the channel won't reconnect, make sure to remove it from channelRequests
-        // so that in case the client reconnects in the future we don't try to open it
-        this.channelRequests = this.channelRequests.filter((cr) => cr !== channelRequest);
-      }
 
       if (channelRequest.isOpen) {
         const channel = this.getChannel(channelRequest.channelId);


### PR DESCRIPTION
`Why
===

Somewhat adjacent to #57. We think this is much more ergonomic and it allows people to use the client with more ease. A usecase for us is that we don't want to reinitialize services and call `openChannel` again when we have to forcefully reconnect (i.e. fork or repl slug change), we'd just have to call `client.close` and then `client.open`, all the channels will be ready to open.

What
============
- Even if the client isn't automatically reconnecting we keep the channel requests around for future manual reconnects (through client.open)
- Added a `destroy` function that cleans up channelRequests and some callbacks to avoid any potential leaks, it also puts the client in a state where trying to reconnect it throws.
  - Ideally we just lose reference to the root object anyway, but this is just to be safe and to make sure we don't do something stupid after we're done with the client.
