### PR TITLE
[v5] Assert named channel isn't opened twice

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -16,6 +16,8 @@ export class Channel extends EventEmitter {
 
   public closed: boolean;
 
+  public name: string | null
+
   // private
   private sendQueue: Array<api.ICommand>;
 
@@ -23,7 +25,7 @@ export class Channel extends EventEmitter {
 
   private requestMap: { [ref: string]: (res: RequestResult) => void };
 
-  constructor() {
+  constructor(name: string | null) {
     super();
 
     this.state = null;
@@ -33,6 +35,7 @@ export class Channel extends EventEmitter {
     this.sendQueue = [];
     this.sendToClient = this.enqueueSend;
     this.requestMap = {};
+    this.name = name;
   }
 
   /**


### PR DESCRIPTION
Why
===
Opening a channel with the same name multiple times causes the container to panic and die. Let's make sure we catch it early on the client so that not all users are affected by a single client, and it'll give us a better idea of why it's happening since we'll have client side traces that reference the error.

What changed
============
- Assert open channels don't have the same name as the new open channel request
- Same but for channels that are inflight and awaiting to be open

Test plan
=========
- Open 2 channels with the same name
- Second call throws