### PR TITLE
Fix client initializing destroyed

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -173,7 +173,7 @@ export class Client<Ctx extends unknown = null> {
     this.channelRequests = [];
     this.retryTimeoutId = null;
     this.fetchTokenAbortController = null;
-    this.destroyed = true;
+    this.destroyed = false;
 
     this.debug({ type: 'breadcrumb', message: 'constructor' });
   }


### PR DESCRIPTION
Why
===

The client should only switch to be beying destroyed after `destroy` has been called. This is a stupid bug, must've slipped in while testing, we need CI on this repo YIKES.

What changed
============

Flipped destroyed flag to start `false`

Test plan
=========
before 
![image](https://user-images.githubusercontent.com/1994028/96651411-a03d8b80-12e9-11eb-9259-061cce041056.png)
after
![image](https://user-images.githubusercontent.com/1994028/96651392-96b42380-12e9-11eb-86c5-3d892ac9808d.png)

