### PR TITLE
Error handling fixes

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1161,10 +1161,19 @@ export class Client<Ctx extends unknown = null> {
 
   private onUnrecoverableError = (e: Error) => {
     if (this.connectionState !== ConnectionState.DISCONNECTED) {
-      this.handleClose({
-        closeReason: ClientCloseReason.Error,
-        error: e,
-      });
+      try {
+        this.handleClose({
+          closeReason: ClientCloseReason.Error,
+          error: e,
+        });
+      } catch (handleCloseErr) {
+        // we need to keep going and report the unrecoverable error regardless of what happens
+        // inside handleClose
+        // eslint-disable-next-line no-console
+        console.error('handleClose errored during unrecoverable error');
+        // eslint-disable-next-line no-console
+        console.error(handleCloseErr);
+      }
     }
 
     if (this.userUnrecoverableErrorHandler) {


### PR DESCRIPTION
Why
===
If `handleClose` throws an error inside `onUnrecoverableError` we don't end up calling the user's registered unrecoverable error handler. We can also end up infinitely recursing `onUnrecoverableError` within `handleClose`. Also sometimes we throw instead of calling `onUnrecoverableError`

What changed
============
- Wrapped `handleClose` inside `onUnrecoverableError` with a try catch that just logs the error in case of an error and continues to call the user's registered error handler
- Protected against infinite recursion for `onUnrecoverableError` inside `handleClose` by checking the close reason before calling `onUnrecoverableError`
- We now consistently call `onUnrecoverableError` instead of sometimes throwing
  - We still throw an error for public methods to stop the execution of the caller

Test plan
=========
1.
- Create client
- Create a scenario where `handleClose` throws
- Notice that user registered error handler is called
2.
- Create client
- connect normally
- Create a scenario where `handleClose` would call `onUnrecoverableError`
- close the client
- `handleClose` is called only twice, once for intentional closure that doesn't complete and another timedue to unrecoverable error
3.
- Create client
- call `open` without chan0cb
- an error is thrown at the caller and the user's registered error handler is called