### PR TITLE
Channel closing improvements

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -441,6 +441,8 @@ export class Client<Ctx extends unknown = null> {
       return;
     }
 
+    const { channelId } = channelRequest;
+
     const chan = this.getChannel(channelRequest.channelId);
     chan.status = 'closing';
 
@@ -454,6 +456,16 @@ export class Client<Ctx extends unknown = null> {
       return;
     }
 
+    this.debug({
+      type: 'breadcrumb',
+      message: 'requestChannelClose',
+      data: {
+        id: channelId,
+        name: channelRequest.options.name,
+        service: channelRequest.options.service,
+      },
+    });
+
     const res = await chan0.request({
       closeChan: {
         action: api.CloseChannel.Action.TRY_CLOSE,
@@ -462,41 +474,52 @@ export class Client<Ctx extends unknown = null> {
     });
 
     if (res.channelClosed) {
-      // channel0 is closed, which means all other channels are already closed
-      return;
-    }
+      this.debug({
+        type: 'breadcrumb',
+        message: 'requestChannelClose:chan0Closed',
+        data: {
+          id: channelId,
+          name: channelRequest.options.name,
+          service: channelRequest.options.service,
+        },
+      });
+    } else {
+      if (res.closeChanRes == null) {
+        this.onUnrecoverableError(new Error('Expected closeChanRes'));
 
-    if (res.closeChanRes == null) {
-      this.onUnrecoverableError(new Error('Expected closeChanRes'));
+        return;
+      }
 
-      return;
-    }
+      const { id } = res.closeChanRes;
 
-    const { id } = res.closeChanRes;
+      if (id == null) {
+        this.onUnrecoverableError(new Error(`Expected id, got ${id}`));
 
-    if (id == null) {
-      this.onUnrecoverableError(new Error(`Expected id, got ${id}`));
+        return;
+      }
 
-      return;
-    }
+      if (id !== channelId) {
+        this.onUnrecoverableError(
+          new Error(`Expected id from closeChanRes to be ${channelId} got ${id}`),
+        );
 
-    this.debug({
-      type: 'breadcrumb',
-      message: 'handleCloseChannel',
-      data: {
-        id: res.closeChanRes.id,
-        reason: res.closeChanRes.status,
-      },
-    });
+        return;
+      }
 
-    if (!this.connectOptions) {
-      this.onUnrecoverableError(new Error('Expected connectionOptions'));
-
-      return;
+      this.debug({
+        type: 'breadcrumb',
+        message: 'requestChannelClose:closeChanRes',
+        data: {
+          id: channelId,
+          name: channelRequest.options.name,
+          service: channelRequest.options.service,
+          closeStatus: res.closeChanRes.status,
+        },
+      });
     }
 
     this.channelRequests = this.channelRequests.filter((cr) => cr !== channelRequest);
-    delete this.channels[id];
+    delete this.channels[channelId];
 
     chan.handleClose({ initiator: 'channel', willReconnect: false });
     if (channelRequest.cleanupCb) {

--- a/src/client.ts
+++ b/src/client.ts
@@ -293,9 +293,9 @@ export class Client<Ctx extends unknown = null> {
     }
 
     let calledClose = false;
-    const closeChannel = async (): Promise<void> => {
+    const closeChannel = () => {
       if (calledClose) {
-        return undefined;
+        return;
       }
 
       calledClose = true;
@@ -307,10 +307,10 @@ export class Client<Ctx extends unknown = null> {
         // request right after it's done opening
         this.channelRequests = this.channelRequests.filter((cr) => cr !== channelRequest);
 
-        return undefined;
+        return;
       }
 
-      return this.requestCloseChannel(channelRequest);
+      this.requestCloseChannel(channelRequest);
     };
 
     return closeChannel;

--- a/src/client.ts
+++ b/src/client.ts
@@ -295,8 +295,6 @@ export class Client<Ctx extends unknown = null> {
     let calledClose = false;
     const closeChannel = async (): Promise<void> => {
       if (calledClose) {
-        this.onUnrecoverableError(new Error('Closing channel multiple times'));
-
         return undefined;
       }
 
@@ -306,7 +304,7 @@ export class Client<Ctx extends unknown = null> {
       if (!channelRequest.isOpen) {
         // Channel is not open, let's just remove it from our list.
         // If there's an inflight open request then we'll be sending a close
-        // request right after it's done.
+        // request right after it's done opening
         this.channelRequests = this.channelRequests.filter((cr) => cr !== channelRequest);
 
         return undefined;


### PR DESCRIPTION
Why
===
You cannot call closeChannel multiple times right now. It's really hard to tell whether or not you can call it. It's also hard to tell  whether you need to call it or not. There's no really good point in limiting the number of calls, so let's allow it in case someone needs to make sure the channel closes and doesn't re-open.

What changed
============
- Allow calling `closeChannel` multiple times
- Don't return a promise from `closeChannel`
  - Although it would be cool to know when the channel actually closes after calling close, we don't have a good reason to need that right now. Now with multiple calls the returned promise will not be honest unless we save the promise or something nasty. Even before this change there was a chance that the opening is inflight and there's a future promise that should've been returned, see: https://github.com/replit/crosis/blob/b1d44baee2d40a21c2f3b7bd1c28a38d94401552/src/client.ts#L431-L435
- Previously if the client disconnects (chan0 closes) during a request to close a channel we returned early from the `requestCloseChannel`. That doesn't make much sense. If the client reconnects we end up opening the channel then requesting a close again lol. Now we keep going with the cleanup regardless of whether the client disconnected during the request or not. 
  - Improved breadcrumbs and asserts around this

Test plan
=========
None of the tests broke :heavy_check_mark: 
If you see a test that you think should be added, lmk