### PR TITLE
Support fetching connection metadata instead of just the token

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Read about the protocol here http://protodoc.turbio.repl.co
 
 The central concept is a "channel" that you can send commands to and receive commands from. Communicating with channels requires a network connection. The goal of this client is to provide an API to manage what happens when a disconnect and/or reconnect happens. How you handle this is up to you and depends on the desired UX. In some cases you'll want to disable UI to prevent any new messages being sent when offline and then re-enable once connected agian. In other cases you might want to give the user the illusion that they are connected and queue message locally while disconnected and send them once reconnected.
 
-When a client successfully connects (`client.open`) the provided callback function is called and passed a channel (this is channel 0). Other channels for specific services can be opened by calling `client.openChannel`. The signature of the callback function for `openChannel` matches the one from `client.open`. 
+When a client successfully connects (`client.open`) the provided callback function is called and passed a channel (this is channel 0). Other channels for specific services can be opened by calling `client.openChannel`. The signature of the callback function for `openChannel` matches the one from `client.open`.
 
-The callback functions provided to `open` and `openChannel` can optionally return a function that will be called when the client or channel is closed. This is useful for cleaning up any logic that depends on a channel being available. 
+The callback functions provided to `open` and `openChannel` can optionally return a function that will be called when the client or channel is closed. This is useful for cleaning up any logic that depends on a channel being available.
 
 ```ts
 import { Client } from '@replit/crosis';
@@ -25,8 +25,10 @@ const client = new Client();
 
 const user = { name: 'example' };
 
-const disposeClient = client.open({ 
+const disposeClient = client.open({
   // This will be called for every connect attempt and reconnect attempt
+  fetchConnectionMetadata: fetch(CONNECTION_METADATA_URL).then((r) => r.json()),
+  // DEPRECATED: Same as above but only returns a subset of the information.
   fetchToken: fetch(TOKEN_URL).then((r) => r.text()),
   // An optinal object that will get passed to open/openChannel callbacks
   context: { user },

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -70,7 +70,8 @@ test('client connect', (done) => {
 
   client.open(
     {
-      fetchConnectionMetadata: () => Promise.resolve({ connectionMetadata: genConnectionMetadata(), aborted: false }),
+      fetchConnectionMetadata: () =>
+        Promise.resolve({ connectionMetadata: genConnectionMetadata(), aborted: false }),
       WebSocketClass: WebSocket,
       context: ctx,
     },
@@ -126,11 +127,14 @@ test('client retries', (done) => {
         tryCount += 1;
 
         if (tryCount === 1) {
-          return Promise.resolve({ connectionMetadata: {
-            token: 'test - bad connection metadata retries',
-            gurl: 'ws://invalid.example.com',
-            conmanURL: 'http://invalid.example.com',
-          }, aborted: false });
+          return Promise.resolve({
+            connectionMetadata: {
+              token: 'test - bad connection metadata retries',
+              gurl: 'ws://invalid.example.com',
+              conmanURL: 'http://invalid.example.com',
+            },
+            aborted: false,
+          });
         }
 
         return Promise.resolve({ connectionMetadata: genConnectionMetadata(), aborted: false });
@@ -162,7 +166,8 @@ test('channel closing itself when client willReconnect', (done) => {
 
   client.open(
     {
-      fetchConnectionMetadata: () => Promise.resolve({ connectionMetadata: genConnectionMetadata(), aborted: false }),
+      fetchConnectionMetadata: () =>
+        Promise.resolve({ connectionMetadata: genConnectionMetadata(), aborted: false }),
       WebSocketClass: WebSocket,
       context: null,
     },
@@ -221,7 +226,8 @@ test('channel open and close', (done) => {
 
   client.open(
     {
-      fetchConnectionMetadata: () => Promise.resolve({ connectionMetadata: genConnectionMetadata(), aborted: false }),
+      fetchConnectionMetadata: () =>
+        Promise.resolve({ connectionMetadata: genConnectionMetadata(), aborted: false }),
       WebSocketClass: WebSocket,
       context: null,
     },
@@ -267,7 +273,8 @@ test('channel skips opening', (done) => {
 
   client.open(
     {
-      fetchConnectionMetadata: () => Promise.resolve({ connectionMetadata: genConnectionMetadata(), aborted: false }),
+      fetchConnectionMetadata: () =>
+        Promise.resolve({ connectionMetadata: genConnectionMetadata(), aborted: false }),
       WebSocketClass: WebSocket,
       context: ctx,
     },
@@ -307,7 +314,8 @@ test('channel skips opening conditionally', (done) => {
 
   client.open(
     {
-      fetchConnectionMetadata: () => Promise.resolve({ connectionMetadata: genConnectionMetadata(), aborted: false }),
+      fetchConnectionMetadata: () =>
+        Promise.resolve({ connectionMetadata: genConnectionMetadata(), aborted: false }),
       WebSocketClass: WebSocket,
       context: null,
     },
@@ -373,7 +381,8 @@ test('openChannel before open', (done) => {
 
   client.open(
     {
-      fetchConnectionMetadata: () => Promise.resolve({ connectionMetadata: genConnectionMetadata(), aborted: false }),
+      fetchConnectionMetadata: () =>
+        Promise.resolve({ connectionMetadata: genConnectionMetadata(), aborted: false }),
       WebSocketClass: WebSocket,
       context: null,
     },
@@ -384,7 +393,6 @@ test('openChannel before open', (done) => {
     },
   );
 });
-
 
 test('closing maintains openChannel requests', (done) => {
   const client = new Client();
@@ -402,7 +410,8 @@ test('closing maintains openChannel requests', (done) => {
         // open again should call this same function
         client.open(
           {
-            fetchConnectionMetadata: () => Promise.resolve({ connectionMetadata: genConnectionMetadata(), aborted: false }),
+            fetchConnectionMetadata: () =>
+              Promise.resolve({ connectionMetadata: genConnectionMetadata(), aborted: false }),
             WebSocketClass: WebSocket,
             context: null,
           },
@@ -417,7 +426,8 @@ test('closing maintains openChannel requests', (done) => {
 
   client.open(
     {
-      fetchConnectionMetadata: () => Promise.resolve({ connectionMetadata: genConnectionMetadata(), aborted: false }),
+      fetchConnectionMetadata: () =>
+        Promise.resolve({ connectionMetadata: genConnectionMetadata(), aborted: false }),
       WebSocketClass: WebSocket,
       context: null,
     },
@@ -435,7 +445,8 @@ test('client rejects opening same channel twice', (done) => {
 
   client.open(
     {
-      fetchConnectionMetadata: () => Promise.resolve({ connectionMetadata: genConnectionMetadata(), aborted: false }),
+      fetchConnectionMetadata: () =>
+        Promise.resolve({ connectionMetadata: genConnectionMetadata(), aborted: false }),
       WebSocketClass: WebSocket,
       context: null,
     },
@@ -471,7 +482,8 @@ test('client reconnects unexpected disconnects', (done) => {
 
   client.open(
     {
-      fetchConnectionMetadata: () => Promise.resolve({ connectionMetadata: genConnectionMetadata(), aborted: false }),
+      fetchConnectionMetadata: () =>
+        Promise.resolve({ connectionMetadata: genConnectionMetadata(), aborted: false }),
       WebSocketClass: WebSocket,
       context: null,
     },
@@ -537,7 +549,10 @@ test('client is closed while reconnecting', (done) => {
       });
     }
 
-    return Promise.resolve({ connectionMetadata: genConnectionMetadata(), aborted: false } as const);
+    return Promise.resolve({
+      connectionMetadata: genConnectionMetadata(),
+      aborted: false,
+    } as const);
   };
 
   client.open(
@@ -681,7 +696,8 @@ test('fetch abort signal works as expected', (done) => {
 
   client.open(
     {
-      fetchConnectionMetadata: (abortSignal) => new Promise((r) => {
+      fetchConnectionMetadata: (abortSignal) =>
+        new Promise((r) => {
           // Listen to abort signal
           abortSignal.onabort = () => {
             onAbort();
@@ -725,8 +741,9 @@ test('can close and open in synchronously without aborting fetch token', (done) 
   client.open(
     {
       // never resolves
-      fetchConnectionMetadata: (abortSignal) => new Promise((r) => {
-        resolveFetchToken = r;
+      fetchConnectionMetadata: (abortSignal) =>
+        new Promise((r) => {
+          resolveFetchToken = r;
 
           abortSignal.onabort = () => {
             onAbort();
@@ -747,18 +764,20 @@ test('can close and open in synchronously without aborting fetch token', (done) 
   resolveFetchToken!({ aborted: true, token: null });
   expect(onAbort).toHaveBeenCalledTimes(1);
   expect(firstChan0Cb).toHaveBeenCalledTimes(1);
-  expect(firstChan0Cb).toHaveBeenLastCalledWith(expect.objectContaining({
-    channel: null,
-    context: null,
-    error: expect.any(Error),
-  }));
+  expect(firstChan0Cb).toHaveBeenLastCalledWith(
+    expect.objectContaining({
+      channel: null,
+      context: null,
+      error: expect.any(Error),
+    }),
+  );
 
   client.setUnrecoverableErrorHandler(done);
 
-
   client.open(
     {
-      fetchConnectionMetadata: () => Promise.resolve({ connectionMetadata: genConnectionMetadata(), aborted: false }),
+      fetchConnectionMetadata: () =>
+        Promise.resolve({ connectionMetadata: genConnectionMetadata(), aborted: false }),
       WebSocketClass: WebSocket,
       context: null,
     },

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,7 +1,7 @@
 import { api } from '@replit/protocol';
 import { Channel } from './channel';
 import { getWebSocketClass, getNextRetryDelay, getConnectionStr } from './util/helpers';
-import { ConnectOptions, ClientCloseReason, ChannelCloseReason, ChannelOptions } from './types';
+import { ConnectOptions, ClientCloseReason, ChannelCloseReason, ChannelOptions, UrlOptions } from './types';
 
 /**
  * The only required option is `fetchConnectionMetadata` (falling back to
@@ -14,6 +14,7 @@ interface ConnectArgs<Ctx> extends Partial<ConnectOptions<Ctx>> {
   fetchToken?: (
     abortSignal: AbortSignal,
   ) => Promise<{ token: null; aborted: true } | { token: string; aborted: false }>;
+  urlOptions?: UrlOptions;
   context: Ctx;
 }
 
@@ -254,7 +255,6 @@ export class Client<Ctx extends unknown = null> {
     this.connectOptions = {
       fetchConnectionMetadata,
       timeout: 10000,
-      urlOptions: defaultUrlOptions,
       ...options,
     };
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -4,10 +4,16 @@ import { getWebSocketClass, getNextRetryDelay, getConnectionStr } from './util/h
 import { ConnectOptions, ClientCloseReason, ChannelCloseReason, ChannelOptions } from './types';
 
 /**
- * The only required option is `fetchToken`, all others are optional and will use defaults
+ * The only required option is `fetchConnectionMetadata` (falling back to
+ * `fetchToken`), all others are optional and will use defaults.
+ *
+ * TODO(lhchavez): Once the migration is done, drop `fetchToken` and only use
+ * `fetchConnectionMetadata`.
  */
-interface ConnectArgs<Ctx> extends Partial<Omit<ConnectOptions<Ctx>, 'fetchToken'>> {
-  fetchToken: ConnectOptions<Ctx>['fetchToken'];
+interface ConnectArgs<Ctx> extends Partial<ConnectOptions<Ctx>> {
+  fetchToken?: (
+    abortSignal: AbortSignal,
+  ) => Promise<{ token: null; aborted: true } | { token: string; aborted: false }>;
   context: Ctx;
 }
 
@@ -74,6 +80,12 @@ type ChannelRequest<Ctx> =
       cleanupCb: null;
     };
 
+const defaultUrlOptions = {
+  secure: false,
+  host: 'eval.repl.it',
+  port: '80',
+};
+
 export class Client<Ctx extends unknown = null> {
   /**
    * Indicates the current state of the connection with the container.
@@ -90,7 +102,7 @@ export class Client<Ctx extends unknown = null> {
 
   /**
    * Supplied to us as the first argument when calling `client.open`.
-   * The most important option is the token getter
+   * The most important option is the connection metadata getter
    */
   private connectOptions: ConnectOptions<Ctx> | null;
 
@@ -148,10 +160,10 @@ export class Client<Ctx extends unknown = null> {
   private retryTimeoutId: ReturnType<typeof setTimeout> | null;
 
   /**
-   * Abort controller is used so that when the user calls
-   * client.close while we're fetching a token, we can be sure
-   * that we don't have a `connect` call lingering around waiting
-   * for a token and eventually continue on as if we still want to connect
+   * Abort controller is used so that when the user calls client.close while
+   * we're fetching connection metadata, we can be sure that we don't have a
+   * `connect` call lingering around waiting for connection metadata and
+   * eventually continue on as if we still want to connect
    */
   private fetchTokenAbortController: AbortController | null;
 
@@ -203,12 +215,32 @@ export class Client<Ctx extends unknown = null> {
       throw error;
     }
 
-    if (!options.fetchToken || typeof options.fetchToken !== 'function') {
-      const error = new Error('You must provide a fetchToken function');
-      this.onUnrecoverableError(error);
+    let fetchConnectionMetadata = options.fetchConnectionMetadata;
+    if (!fetchConnectionMetadata || typeof fetchConnectionMetadata !== 'function') {
+      const fetchToken = options.fetchToken;
+      if (!fetchToken || typeof fetchToken !== 'function') {
+        const error = new Error('You must provide a fetchConnectionMetadata/fetchToken function');
+        this.onUnrecoverableError(error);
 
-      // throw to stop the execution of the caller
-      throw error;
+        // throw to stop the execution of the caller
+        throw error;
+      }
+      const { secure, host, port } = options.urlOptions || defaultUrlOptions;
+
+      fetchConnectionMetadata = async (abortSignal: AbortSignal) => {
+        const { token, aborted } = await fetchToken(abortSignal);
+        if (aborted || !token) {
+          return { connectionMetadata: null, aborted: true };
+        }
+        return {
+          connectionMetadata: {
+            token,
+            gurl: `ws${secure ? 's' : ''}://${host}:${port}`,
+            conmanURL: `http${secure ? 's' : ''}://${host}:${port}`,
+          },
+          aborted: false,
+        };
+      };
     }
 
     if (this.destroyed) {
@@ -220,12 +252,9 @@ export class Client<Ctx extends unknown = null> {
     }
 
     this.connectOptions = {
+      fetchConnectionMetadata,
       timeout: 10000,
-      urlOptions: {
-        secure: false,
-        host: 'eval.repl.it',
-        port: '80',
-      },
+      urlOptions: defaultUrlOptions,
       ...options,
     };
 
@@ -668,9 +697,11 @@ export class Client<Ctx extends unknown = null> {
     const abortController = new AbortController();
     this.fetchTokenAbortController = abortController;
 
-    let tokenFetchResult;
+    let connectionMetadataFetchResult;
     try {
-      tokenFetchResult = await this.connectOptions.fetchToken(abortController.signal);
+      connectionMetadataFetchResult = await this.connectOptions.fetchConnectionMetadata(
+        abortController.signal,
+      );
     } catch (e) {
       this.onUnrecoverableError(e);
 
@@ -679,7 +710,7 @@ export class Client<Ctx extends unknown = null> {
 
     this.fetchTokenAbortController = null;
 
-    const { token, aborted } = tokenFetchResult;
+    const { connectionMetadata, aborted } = connectionMetadataFetchResult;
 
     if (abortController.signal.aborted !== aborted) {
       // the aborted return value and the abort signal should be equivalent
@@ -688,7 +719,7 @@ export class Client<Ctx extends unknown = null> {
         // that means we shouldn't be calling `handleConnectError` because chan0Cb is null!
         this.onUnrecoverableError(
           new Error(
-            'Expected abort returned from fetchToken to be truthy when the controller aborts',
+            'Expected abort returned from fetchConnectionMetadata to be truthy when the controller aborts',
           ),
         );
 
@@ -704,21 +735,21 @@ export class Client<Ctx extends unknown = null> {
       return;
     }
 
-    if (token && aborted) {
-      this.onUnrecoverableError(new Error('Expected either aborted or a token'));
+    if (connectionMetadata && aborted) {
+      this.onUnrecoverableError(new Error('Expected either aborted or a connectionMetadata'));
 
       return;
     }
 
     if (aborted) {
-      // Just return. The user called `client.close leading to a token abort
+      // Just return. The user called `client.close leading to a connectionMetadata abort
       // chan0Cb will be called with with an error Channel close, no need to do anything here.
       return;
     }
 
-    if (!token) {
+    if (!connectionMetadata) {
       this.onUnrecoverableError(
-        new Error('Expected token to be a string or request to be aborted'),
+        new Error('Expected connectionMetadata to be non-empty or request to be aborted'),
       );
 
       return;
@@ -730,7 +761,7 @@ export class Client<Ctx extends unknown = null> {
       return;
     }
 
-    const connStr = getConnectionStr(token, this.connectOptions.urlOptions);
+    const connStr = getConnectionStr(connectionMetadata);
     const ws = new WebSocketClass(connStr);
 
     ws.binaryType = 'arraybuffer';
@@ -868,7 +899,8 @@ export class Client<Ctx extends unknown = null> {
 
           // defer closing if the user decides to call client.close inside chan0Cb
           const originalClose = this.close;
-          this.close = () => setTimeout(() => {
+          this.close = () =>
+            setTimeout(() => {
               originalClose();
             }, 0);
 
@@ -1035,8 +1067,9 @@ export class Client<Ctx extends unknown = null> {
       }
 
       if (this.ws && this.fetchTokenAbortController) {
-        // Fetching a token is required prior to initializing a websocket, we can't
-        // have both at the same time as the abort controller is unset after we fetch the token
+        // Fetching connection metadata is required prior to initializing a
+        // websocket, we can't have both at the same time as the abort
+        // controller is unset after we fetch the connection metadata.
         this.onUnrecoverableError(
           new Error('fetchTokenAbortController and websocket exist simultaneously'),
         );

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,7 +53,6 @@ export interface ConnectOptions<Ctx> {
     | { connectionMetadata: null; aborted: true }
     | { connectionMetadata: GovalMetadata; aborted: false }
   >;
-  urlOptions: UrlOptions;
   timeout: number | null;
   WebSocketClass?: typeof WebSocket;
   context: Ctx;

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,8 +40,19 @@ export interface UrlOptions {
   port: string;
 }
 
+export interface GovalMetadata {
+  token: string;
+  gurl: string;
+  conmanURL: string;
+}
+
 export interface ConnectOptions<Ctx> {
-  fetchToken: (abortSignal: AbortSignal) => Promise<{ token: null, aborted: true } | { token: string, aborted: false }>;
+  fetchConnectionMetadata: (
+    abortSignal: AbortSignal,
+  ) => Promise<
+    | { connectionMetadata: null; aborted: true }
+    | { connectionMetadata: GovalMetadata; aborted: false }
+  >;
   urlOptions: UrlOptions;
   timeout: number | null;
   WebSocketClass?: typeof WebSocket;

--- a/src/util/helpers.ts
+++ b/src/util/helpers.ts
@@ -1,4 +1,4 @@
-import { ConnectOptions, UrlOptions } from '../types';
+import { ConnectOptions, GovalMetadata } from '../types';
 
 const BACKOFF_FACTOR = 1.7;
 const MAX_BACKOFF = 15000;
@@ -51,8 +51,6 @@ export function getWebSocketClass(options: ConnectOptions<unknown>) {
 /**
  * Given a token and the URL options, creates a websocket connection string
  */
-export function getConnectionStr(token: string, urlOptions: UrlOptions) {
-  const { secure, host, port } = urlOptions;
-
-  return `ws${secure ? 's' : ''}://${host}:${port}/wsv2/${token}`;
+export function getConnectionStr(connectionMetadata: GovalMetadata) {
+  return new URL(`/wsv2/${connectionMetadata.token}`, connectionMetadata.gurl).toString();
 }

--- a/src/util/helpers.ts
+++ b/src/util/helpers.ts
@@ -49,7 +49,7 @@ export function getWebSocketClass(options: ConnectOptions<unknown>) {
 }
 
 /**
- * Given a token and the URL options, creates a websocket connection string
+ * Given connection metadata, creates a websocket connection string
  */
 export function getConnectionStr(connectionMetadata: GovalMetadata) {
   return new URL(`/wsv2/${connectionMetadata.token}`, connectionMetadata.gurl).toString();


### PR DESCRIPTION
Why
===

This is part of a migration that allows all the information that's needed to construct the URL to be provided by a single function.

What changed
============

This change starts the deprecation of `fetchToken`/`urlOptions`
combination as what gets the connection token / URL and instead relies
on `fetchConnectionMetadata`, which does both.

Test plan
=========

```shell
yarn test
```

(this also has a backwards-compatibility layer to avoid breaking existing clients).