### PR TITLE
Support connection metadata instead of just the token

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
 import './utf8_spooky_monkeypatch'; // pbjs's utf8 decoder is borked
 
-export { Client } from './client';
+export { Client, ConnectArgs, UrlOptions } from './client';
 export { Channel } from './channel';


### PR DESCRIPTION
Why
===

This is part of a migration that allows all the information that's needed to construct the URL to be provided by a single function. Crosisv5 edition!

What changed
============

This change starts the deprecation of the `token`/`urlOptions` combination
in favor of `connectionMetadata`, which contains all the information
needed.

Test plan
=========

localhost repl.it still works!
