### PR TITLE
Use TLS by default

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -65,9 +65,9 @@ export interface ConnectArgs extends Partial<ConnectOptions> {
 }
 
 const defaultUrlOptions = {
-  secure: false,
+  secure: true,
   host: 'eval.repl.it',
-  port: '80',
+  port: '443',
 };
 
 const defaultPollingHost = 'gp-v2.herokuapp.com';


### PR DESCRIPTION
Why
===

https://app.asana.com/0/1108711276181834/1199341815264173/f

What changed
============

This change makes it such that if the caller does not provide an
override gurl, it will use wss/https by default.

Test plan
=========

Default URLs are now secure.
