### PR TITLE
Use TLS by default (v6)

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -82,9 +82,9 @@ type ChannelRequest<Ctx> =
     };
 
 const defaultUrlOptions = {
-  secure: false,
+  secure: true,
   host: 'eval.repl.it',
-  port: '80',
+  port: '443',
 };
 
 export class Client<Ctx extends unknown = null> {


### PR DESCRIPTION
Why
===

https://app.asana.com/0/1108711276181834/1199341815264173/f

What changed
============

This change makes it such that if the caller does not provide an
override gurl, it will use wss/https by default.

Test plan
=========

Default URLs are now secure.
