### PR TITLE
Allow specifying a different URL to connect to in the EIO compat

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -141,9 +141,14 @@ export class Client extends EventEmitter {
   static getConnectionStr(connectionMetadata: GovalMetadata, pollingHost?: string): string {
     const gurl = urllib.parse(connectionMetadata.gurl);
     if (pollingHost) {
+      gurl.hostname = pollingHost;
       gurl.host = pollingHost;
+      gurl.pathname = `/wsv2/${connectionMetadata.token}/${encodeURIComponent(
+        connectionMetadata.gurl,
+      )}`;
+    } else {
+      gurl.pathname = `/wsv2/${connectionMetadata.token}`;
     }
-    gurl.pathname = `/wsv2/${connectionMetadata.token}`;
     return urllib.format(gurl);
   }
 


### PR DESCRIPTION
Why
===

https://app.asana.com/0/0/1199404367853566/f

What changed
============

This change appends the original URL that we were supposed to connect to
if we are going to go through the EIO compat route. This allows for
multi-cluster support!

Depends on: https://github.com/replit/goval-proxy-v2/pull/2

Test plan
=========

```shell
~/goval-proxy-v2$ npm run start
```

Then fiddle with repl-it-web to coerce it to go through the EIO compat route. See lots of requests to `http://localhost:3003/wsv2/[token]/wss%3A%2F%2Feval.repl.it?...` in Chrome network tools.