### PR TITLE
Allow fetchConnectionMetadata to fail with a recoverable error

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,4 +3,9 @@ import './util/utf8ReadMonkeypatch'; // pbjs's utf8 decoder is borked
 
 export { Client } from './client';
 export { Channel } from './channel';
-export { ChannelCloseReason, ChannelOptions, ClientCloseReason } from './types';
+export {
+  ChannelCloseReason,
+  ChannelOptions,
+  ClientCloseReason,
+  FetchConnectionMetadataResult,
+} from './types';

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,12 +46,33 @@ export interface GovalMetadata {
   conmanURL: string;
 }
 
+export enum FetchConnectionMetadataResult {
+  /**
+   * Fetch was successful.
+   */
+  Ok = 'Ok',
+
+  /**
+   * Fetch was aborted.
+   */
+  Aborted = 'Aborted',
+
+  /**
+   * The fetch failed due to a recoverable error (mostly a transient network
+   * condition).
+   */
+  RetriableError = 'RetriableError',
+}
+
 export interface ConnectOptions<Ctx> {
   fetchConnectionMetadata: (
     abortSignal: AbortSignal,
   ) => Promise<
-    | { connectionMetadata: null; aborted: true }
-    | { connectionMetadata: GovalMetadata; aborted: false }
+    | {
+        connectionMetadata: null;
+        result: Exclude<FetchConnectionMetadataResult, FetchConnectionMetadataResult.Ok>;
+      }
+    | { connectionMetadata: GovalMetadata; result: FetchConnectionMetadataResult.Ok }
   >;
   timeout: number | null;
   WebSocketClass?: typeof WebSocket;


### PR DESCRIPTION
Why
===

Currently if there is _any_ problem with fetching the connection metadata (say, the network was flaky, or your repl is being transferred across clusters, the latter maybe persisting for several seconds), the workspace crashes. Instead of crashing, we can allow the caller to specify whether an error is retriable to make things more resilient.

What changed
============

This change allows fetchConectionMetadata to fail with a recoverable
error (e.g. transient network failures or a container transfer) and try
again after waiting a bit.

Test plan
=========

Made Lore always return 409 (repl being transferred), caught that in the workspace (in https://github.com/replit/repl-it-web/pull/8536) and made that a retriable error, did not see a workspace crash.

(also added a new test, which passes).