### PR TITLE
Handle closing channel synchronously from within openChannelCb

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -309,7 +309,6 @@ test('channel open and close', (done) => {
       expect(channel?.status).toBe('closing');
     });
 
-
     return ({ willReconnect }) => {
       expect(willReconnect).toBeFalsy();
       expect(channel?.status).toBe('closed');

--- a/src/client.ts
+++ b/src/client.ts
@@ -456,13 +456,19 @@ export class Client<Ctx extends unknown = null> {
       // TODO we should stop relying on mutating the same channelrequest
       (channelRequest as ChannelRequest<Ctx>).channelId = id;
       (channelRequest as ChannelRequest<Ctx>).isOpen = true;
+
+      // Make sure to save this value as the user can call closeChannel within openChannelCb
+      // we want to avoid making the call to requestCloseChannel twice, once from within
+      // openChannelCb and once here.
+      const closeRequested = channelRequest.closeRequested;
+
       (channelRequest as ChannelRequest<Ctx>).cleanupCb = openChannelCb({
         channel,
         error: null,
         context: this.connectOptions.context,
       });
 
-      if (channelRequest.closeRequested) {
+      if (closeRequested) {
         // While we're opening the channel, we got a request to close this channel
         // let's take care of that and request a close
         this.requestCloseChannel(channelRequest);
@@ -577,7 +583,7 @@ export class Client<Ctx extends unknown = null> {
     this.debug({ type: 'breadcrumb', message: 'user close' });
 
     if (!this.chan0Cb || !this.connectOptions) {
-      const error = new Error('Must call client.connect before closing');
+      const error = new Error('Must call client.open before closing');
       this.onUnrecoverableError(error);
 
       // throw to stop the execution of the caller

--- a/src/client.ts
+++ b/src/client.ts
@@ -460,7 +460,7 @@ export class Client<Ctx extends unknown = null> {
       // Make sure to save this value as the user can call closeChannel within openChannelCb
       // we want to avoid making the call to requestCloseChannel twice, once from within
       // openChannelCb and once here.
-      const closeRequested = channelRequest.closeRequested;
+      const { closeRequested } = channelRequest;
 
       (channelRequest as ChannelRequest<Ctx>).cleanupCb = openChannelCb({
         channel,


### PR DESCRIPTION
Why
===
The client has code to handle closing a channel after it's been opened. When the user calls close on a channel synchronously inside `openChannelCb` we end up in a weird state where we end up calling `requestCloseChannel` twice.

What changed
============

We might be able to clean this up and make it more robust later, but for now this works. We save the `closeRequested` flag before calling `openChannelCb` making it so that we only call `requestCloseChannel` once.

Test plan
=========
- Added a test
