### PR TITLE
Allow passing a thunk for service when opening a channel

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -269,6 +269,65 @@ test('channel open and close', (done) => {
   });
 });
 
+test('channel accepts a thunk for service', (done) => {
+  const onUnrecoverableError = jest.fn<void, [Error]>();
+  const context = { username: 'aghanim' };
+  const client = new Client<typeof context>();
+  client.setUnrecoverableErrorHandler(done);
+
+  const channelClose = jest.fn();
+
+  client.open(
+    {
+      fetchConnectionMetadata: () =>
+        Promise.resolve({
+          ...genConnectionMetadata(),
+          error: null,
+        }),
+      WebSocketClass: WebSocket,
+      context,
+    },
+    ({ channel, error }) => {
+      expect(error).toEqual(null);
+      expect(channel?.status).toBe('open');
+
+      return () => {
+        expect(channelClose).toHaveBeenCalled();
+
+        expect(onUnrecoverableError).toHaveBeenCalledTimes(0);
+        done();
+      };
+    },
+  );
+
+  const close = client.openChannel(
+    {
+      service: (ctx) => {
+        expect(ctx.username).toEqual('aghanim');
+
+        return 'exec';
+      },
+    },
+    ({ channel, error }) => {
+      expect(channel?.status).toBe('open');
+      expect(error).toBe(null);
+
+      setTimeout(() => {
+        close();
+        expect(channel?.status).toBe('closing');
+      });
+
+      return ({ willReconnect }) => {
+        expect(willReconnect).toBeFalsy();
+        expect(channel?.status).toBe('closed');
+
+        channelClose();
+        client.close();
+      };
+    },
+  );
+});
+
 test('channel open and close from within openChannelCb synchornously', (done) => {
   const onUnrecoverableError = jest.fn<void, [Error]>();
   const client = new Client();

--- a/src/client.ts
+++ b/src/client.ts
@@ -452,12 +452,17 @@ export class Client<Ctx extends unknown = null> {
       return;
     }
 
+    const service =
+      typeof options.service === 'string'
+        ? options.service
+        : options.service(this.connectOptions.context);
+
     this.debug({
       type: 'breadcrumb',
       message: 'handleOpenChannel',
       data: {
         name: options.name,
-        service: options.service,
+        service,
         action,
       },
     });
@@ -477,7 +482,7 @@ export class Client<Ctx extends unknown = null> {
       ref,
       openChan: {
         name: options.name,
-        service: options.service,
+        service,
         action,
       },
     });

--- a/src/types.ts
+++ b/src/types.ts
@@ -109,12 +109,16 @@ export type ChannelCloseReason =
       willReconnect: false;
     };
 
+interface ServiceThunk<Ctx> {
+  (context: Ctx): string;
+}
+
 /**
  * See [[Client.openChannel]]
  */
 export interface ChannelOptions<Ctx> {
   name?: string;
-  service: string;
+  service: string | ServiceThunk<Ctx>;
   action?: api.OpenChannel.Action;
   skip?: (context: Ctx) => boolean;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -109,6 +109,12 @@ export type ChannelCloseReason =
       willReconnect: false;
     };
 
+/**
+ * When opening a channel, the service parameter
+ * accepts passing in a function that returns a
+ * service name. Use this when you need to use context
+ * to determine which service to use.
+ */
 interface ServiceThunk<Ctx> {
   (context: Ctx): string;
 }


### PR DESCRIPTION
Why
===

Sometimes we need some data from the context to decide what service to open (i.e. repl ownership information to decide `gcsfiles` vs `files`).

What changed
============
What the title says, basically we can pass a thunk that takes the context as an argument and return the service string that we need.

In the client we call the function or just use the passed in string conditionally.

Test plan
=========
- Added a test