### PR TITLE
Fix token generation for CI and debug mode

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,5 +30,6 @@ jobs:
 
       - name: Test
         env:
-          TOKEN_SECRET: ${{ secrets.TOKEN_SECRET }}
+          USER_KEY_ID: ${{ secrets.USER_KEY_ID }}
+          USER_PRIVATE_KEY_PEM: ${{ secrets.USER_PRIVATE_KEY_PEM }}
         run: yarn run test

--- a/README.md
+++ b/README.md
@@ -114,13 +114,13 @@ const closeChannel = client.openChannel({ service: 'exec' }, function open({ cha
 To run tests run
 
 ```bash
-TOKEN_SECRET=XXXXXXXXXX yarn test
+USER_KEY_ID=XXXX USER_PRIVATE_KEY_PEM=XXXX yarn test
 ```
 
 To interact with a connected client in the browser run
 
 ```bash
-TOKEN_SECRET=XXXXXXXXXX yarn debug
+USER_KEY_ID=XXXX USER_PRIVATE_KEY_PEM=XXXX yarn debug
 ```
 
 You can then access the client from the console an send messages like:
@@ -131,6 +131,6 @@ window.client.send({ exec: { args: ['kill', '1'] } });
 
 ### Releasing
 
-To release, just run `TOKEN_SECRET=XXXXXXXXXX yarn version`, it will prompt you for a version, then it will push to github and release to npm.
+To release, just run `USER_KEY_ID=XXXX USER_PRIVATE_KEY_PEM=XXXX yarn version`, it will prompt you for a version, then it will push to github and release to npm.
 
 To update documentation, go to https://crosisdoc.util.repl.co/__repl and run `. ./updatedocs.sh`

--- a/debug/genConnectionMetadata.js
+++ b/debug/genConnectionMetadata.js
@@ -1,9 +1,12 @@
 /* eslint-disable  @typescript-eslint/no-var-requires */
+const crypto = require('crypto');
 const { api } = require('@replit/protocol');
 const paseto = require('./paseto');
 
 const keyId = process.env.USER_KEY_ID;
-const govalPrivateKey = crypto.createPrivateKey(process.env.USER_PRIVATE_KEY_PEM.replace(/\\n/, '\n'));
+const govalPrivateKey = crypto.createPrivateKey(
+  process.env.USER_PRIVATE_KEY_PEM.replace(/\\n/, '\n'),
+);
 const govalPublicKey = crypto.createPublicKey(process.env.USER_PUBLIC_KEY_PEM.replace(/\\n/, '\n'));
 
 if (!keyId || !govalPrivateKey || !govalPublicKey) {

--- a/debug/genConnectionMetadata.js
+++ b/debug/genConnectionMetadata.js
@@ -3,8 +3,8 @@ const { api } = require('@replit/protocol');
 const paseto = require('./paseto');
 
 const keyId = process.env.USER_KEY_ID;
-const govalPrivateKey = process.env.USER_PRIVATE_KEY_PEM.replace(/\\n/, '\n');
-const govalPublicKey = process.env.USER_PUBLIC_KEY_PEM.replace(/\\n/, '\n');
+const govalPrivateKey = crypto.createPrivateKey(process.env.USER_PRIVATE_KEY_PEM.replace(/\\n/, '\n'));
+const govalPublicKey = crypto.createPublicKey(process.env.USER_PUBLIC_KEY_PEM.replace(/\\n/, '\n'));
 
 if (!keyId || !govalPrivateKey || !govalPublicKey) {
   throw new Error('expected all token keys to be present');

--- a/debug/genConnectionMetadata.js
+++ b/debug/genConnectionMetadata.js
@@ -3,15 +3,14 @@ const crypto = require('crypto');
 const { api } = require('@replit/protocol');
 const paseto = require('./paseto');
 
+if (!(process.env.USER_KEY_ID || process.env.USER_PRIVATE_KEY_PEM)) {
+  throw new Error('Expected USER_KEY_ID and USER_PRIVATE_KEY_PEM in ENV');
+}
+
 const keyId = process.env.USER_KEY_ID;
 const govalPrivateKey = crypto.createPrivateKey(
   process.env.USER_PRIVATE_KEY_PEM.replace(/\\n/, '\n'),
 );
-const govalPublicKey = crypto.createPublicKey(process.env.USER_PUBLIC_KEY_PEM.replace(/\\n/, '\n'));
-
-if (!keyId || !govalPrivateKey || !govalPublicKey) {
-  throw new Error('expected all token keys to be present');
-}
 
 function genConnectionMetadata() {
   const now = Date.now();

--- a/debug/genConnectionMetadata.js
+++ b/debug/genConnectionMetadata.js
@@ -9,7 +9,7 @@ if (!(process.env.USER_KEY_ID || process.env.USER_PRIVATE_KEY_PEM)) {
 
 const keyId = process.env.USER_KEY_ID;
 const govalPrivateKey = crypto.createPrivateKey(
-  process.env.USER_PRIVATE_KEY_PEM.replace(/\\n/, '\n'),
+  process.env.USER_PRIVATE_KEY_PEM.replace(/\\n/g, '\n'),
 );
 
 function genConnectionMetadata() {

--- a/debug/paseto.js
+++ b/debug/paseto.js
@@ -1,0 +1,101 @@
+// @flow
+/* eslint-disable */
+// A worker-thread-free implementation of PASETO.
+// Reference: https://github.com/paragonie/paseto/blob/master/docs/01-Protocol-Versions/Version2.md
+// copied from repl-it-web, should probably put it on npm
+
+const crypto = require('crypto');
+
+const header = 'v2.public.';
+
+/**
+ * Little-Endian binary encoding of a 64-bit integer.
+ *
+ * This is documented in
+ * https://github.com/paragonie/paseto/blob/master/docs/01-Protocol-Versions/Common.md#authentication-padding
+ */
+function le64(n /*: number */) /*: Buffer */ {
+  const buf = Buffer.allocUnsafe(8);
+  for (let i = 0; i < 8; i++) {
+    if (i === 7) {
+      // Clear the MSB for interoperability.
+      n &= 0x7f;
+    }
+
+    buf.writeUInt8(n & 0xff, i);
+    n >>= 8;
+  }
+
+  return buf;
+}
+
+/**
+ * Pre-Authentication Encoding. This is used to prevent a collision with only a
+ * partially controlled plaintext.
+ *
+ * This is documented in
+ * https://github.com/paragonie/paseto/blob/master/docs/01-Protocol-Versions/Common.md#authentication-padding
+ */
+function pae(...pieces /*: Buffer[] */) /*: Buffer */ {
+  const finalPieces = [];
+  finalPieces.push(le64(pieces.length));
+  for (const piece of pieces) {
+    finalPieces.push(le64(Buffer.byteLength(piece)));
+    finalPieces.push(piece);
+  }
+
+  return Buffer.concat(finalPieces);
+}
+
+function base64UrlSafe(data /*: Buffer */) /*: string */ {
+  return data.toString('base64').replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_');
+}
+
+function sign(
+  privateKey /*: crypto$KeyObject */,
+  message /*: Buffer */,
+  footer /*: Buffer */,
+) /*: string */ {
+  const m2 = pae(Buffer.from(header), message, footer);
+  const sig = crypto.sign(null, m2, privateKey);
+
+  return `${header}${base64UrlSafe(Buffer.concat([message, sig]))}.${base64UrlSafe(footer)}`;
+}
+
+function verify(
+  publicKey /*: crypto$KeyObject */,
+  signedMessage /*: string */,
+) /*: { message: Buffer, footer: Buffer } */ {
+  if (signedMessage.indexOf(header) !== 0) {
+    throw new Error(`Invalid signedMessage. Did not start with "${header}"`);
+  }
+
+  const pieces = signedMessage.split('.');
+  if (pieces.length !== 4) {
+    throw new Error(`Invalid number of pieces. got ${pieces.length}, expected 4`);
+  }
+
+  const payload = Buffer.from(pieces[2], 'base64');
+  const footer = Buffer.from(pieces[3], 'base64');
+  if (Buffer.byteLength(payload) <= 64) {
+    throw new Error(
+      `Invalid signed message length. got ${Buffer.byteLength(payload)}, expected > 64`,
+    );
+  }
+
+  const message = payload.slice(0, Buffer.byteLength(payload) - 64);
+  const sig = payload.slice(Buffer.byteLength(payload) - 64);
+
+  const m2 = pae(Buffer.from(header), message, footer);
+  if (!crypto.verify(null, m2, publicKey, sig)) {
+    throw new Error('Invalid signed message. Could not verify.');
+  }
+
+  return { message, footer };
+}
+
+module.exports = {
+  pae,
+  sign,
+  verify,
+};

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint": "eslint --ext .js,.ts src/ src.browser/",
     "build": "tsc",
     "build:browser": "yarn clean && yarn build && parcel build src.browser/index.js -d dist.browser --out-file crosis.js",
-    "debug": "node src/debug/server.js",
+    "debug": "node debug/server.js",
     "clean": "rm -rf dist dist.browser",
     "docs": "typedoc --out docs --name crosis src/index.ts node_modules/@replit/protocol/index.d.ts",
     "test": "jest --no-cache",

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -10,12 +10,6 @@ const genConnectionMetadata = require('../../debug/genConnectionMetadata');
 // eslint-disable-next-line
 const WebSocket = require('ws');
 
-const TOKEN_SECRET = process.env.TOKEN_SECRET as string;
-
-if (!TOKEN_SECRET) {
-  throw new Error('TOKEN_SECRET env variable is required to run tests');
-}
-
 function genToken() {
   return genConnectionMetadata().token;
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -53,7 +53,7 @@ type ChannelRequest<Ctx> =
 
 const defaultUrlOptions = {
   secure: true,
-  host: 'eval.repl.it',
+  host: 'eval.global.replit.com',
   port: '443',
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1302,7 +1302,7 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=
 
-"@replit/protocol@^0.2.18":
+"@replit/protocol@0.x.x":
   version "0.2.18"
   resolved "https://registry.yarnpkg.com/@replit/protocol/-/protocol-0.2.18.tgz#ac57637d9616699ac3b2250cecd9a1cd7214edb0"
   integrity sha512-AtQvBtncBXQ1+ow7sI6H/HqJeZvwVu4pHFxDN2Z70yw20f9pP+ctd7L1qMKF9zGvM0+D2T4Tk8rvh8AvN24mrA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1302,10 +1302,10 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=
 
-"@replit/protocol@0.x.x":
-  version "0.2.16"
-  resolved "https://registry.yarnpkg.com/@replit/protocol/-/protocol-0.2.16.tgz#7d39b30db7549388af88b6c07bf0ce0b6ae90076"
-  integrity sha512-3RWXkEB6sur5fCC1puAmKrXIQhwQEgPt/Mzy6oCCWdR4fFPpbmlkyby5Dnk50As5nyhx7mySPOYLeDG295Hi4w==
+"@replit/protocol@^0.2.18":
+  version "0.2.18"
+  resolved "https://registry.yarnpkg.com/@replit/protocol/-/protocol-0.2.18.tgz#ac57637d9616699ac3b2250cecd9a1cd7214edb0"
+  integrity sha512-AtQvBtncBXQ1+ow7sI6H/HqJeZvwVu4pHFxDN2Z70yw20f9pP+ctd7L1qMKF9zGvM0+D2T4Tk8rvh8AvN24mrA==
   dependencies:
     protobufjs "^6.10.2"
 


### PR DESCRIPTION
Why
===
Tests can't run because we're using an old token generation method

What changed
============
Use shiny new token generation method. This hardcodes `global` cluster, we can improve it later on to contact lore if we want to. I added secrets to the repo, feel free to review those too https://docs.github.com/en/actions/reference/encrypted-secrets

Test plan
=========
Once goval updates with the new public key for crosis ci, the tests in here should run (and hopefully pass).
Keys added in replit/goval#2336