### PR TITLE
Allow opening channels with the same name if others are closing

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -367,7 +367,13 @@ export class Client<Ctx extends unknown = null> {
    *```
    */
   public openChannel = (options: ChannelOptions<Ctx>, cb: OpenChannelCb<Ctx>): (() => void) => {
-    if (options.name && this.channelRequests.some((cr) => cr.options.name === options.name)) {
+    if (
+      options.name &&
+      this.channelRequests.some((cr) => !cr.closeRequested && cr.options.name === options.name)
+    ) {
+      // The protocol forbids opening a channel with the same name, so we're gonna prevent that early
+      // so that we can give the caller a good stack trace to work with. If the channel is queued for
+      // closure then we allow it.
       const error = new Error(`Channel with name ${options.name} already opened`);
       this.onUnrecoverableError(error);
 


### PR DESCRIPTION
Why
===

The protocol forbids opening a channel with the same name, so when a client tries to do that we throw. However, if the user called close on the old named channel, we should allow it. This should be safe from a protocol perspective since the close request should get in before the next open request. Ideally we `await` closing the channel before trying to open a new one, but it ends up being a tedious task to keep the handle for closing around and waiting for it, both from the client's perspective and caller's perspective.

What changed
============
Only disallow opening a channel with the same name if there are any that are not pending a clousre.

Test plan
=========
I wrote a test to cover this case.