### PR TITLE
Fix grammar and typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Read about the protocol here http://protodoc.turbio.repl.co
 
 ### Usage and concepts
 
-The central concept is a "channel" that you can send commands to and receive commands from. Communicating with channels requires a network connection. The goal of this client is to provide an API to manage the connection (including disconnects and reconnects), opening channels, and a way to send a receive messages/commands on channels. How you handle this is up to you and depends on the desired UX. In some cases you'll want to disable UI to prevent any new messages being sent when offline and then re-enable once connected agian. In other cases you might want to give the user the illusion that they are connected and queue message locally while disconnected and send them once reconnected.
+The central concept is a "channel" that you can send commands to and receive commands from. Communicating with channels requires a network connection. The goal of this client is to provide an API to manage the connection (including disconnects and reconnects), opening channels, and a way to send a receive messages/commands on channels. How you handle this is up to you and depends on the desired UX. In some cases you'll want to disable UI to prevent any new messages from being sent when offline and then re-enable once connected again. In other cases you might want to give the user the illusion that they are connected and queue messages locally while disconnected and send them once reconnected.
 
 Here is an example usage, for more details on usage please refer to the API docs at https://crosisdoc.util.repl.co/
 


### PR DESCRIPTION
Why
===

 - "again" is misspelled
 - "queue message" makes no sense
 - prevent **from** being

What changed
============

 - Rewrite "agian" as "again"
 - Add a "s" (queue message **s**)
 - Add this "from"