### PR TITLE
Remove support for `fetchToken`

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -10,10 +10,6 @@ const genConnectionMetadata = require('../../debug/genConnectionMetadata');
 // eslint-disable-next-line
 const WebSocket = require('ws');
 
-function genToken() {
-  return genConnectionMetadata().token;
-}
-
 jest.setTimeout(10 * 1000);
 
 test('client connect', (done) => {
@@ -75,32 +71,6 @@ test('client connect with connection metadata retry', (done) => {
     },
     ({ channel, error, context }) => {
       expect(tryCount).toBe(2);
-      expect(channel?.status).toBe('open');
-      expect(context).toBe(ctx);
-      expect(error).toEqual(null);
-
-      client.close();
-
-      return () => {
-        done();
-      };
-    },
-  );
-});
-
-test('client connect (fetchToken)', (done) => {
-  const client = new Client<{ username: string }>();
-  client.setUnrecoverableErrorHandler(done);
-
-  const ctx = { username: 'zyzz' };
-
-  client.open(
-    {
-      fetchToken: () => Promise.resolve({ token: genToken(), aborted: false }),
-      WebSocketClass: WebSocket,
-      context: ctx,
-    },
-    ({ channel, error, context }) => {
       expect(channel?.status).toBe('open');
       expect(context).toBe(ctx);
       expect(error).toEqual(null);

--- a/src/client.ts
+++ b/src/client.ts
@@ -58,12 +58,6 @@ type ChannelRequest<Ctx> =
       cleanupCb: null;
     };
 
-const defaultUrlOptions = {
-  secure: true,
-  host: 'eval.global.replit.com',
-  port: '443',
-};
-
 export class Client<Ctx extends unknown = null> {
   /**
    * Indicates the current state of the connection with the container.
@@ -247,38 +241,6 @@ export class Client<Ctx extends unknown = null> {
       throw error;
     }
 
-    let { fetchConnectionMetadata } = options;
-    if (!fetchConnectionMetadata || typeof fetchConnectionMetadata !== 'function') {
-      const { fetchToken } = options;
-      if (!fetchToken || typeof fetchToken !== 'function') {
-        const error = new Error('You must provide a fetchConnectionMetadata/fetchToken function');
-        this.onUnrecoverableError(error);
-
-        // throw to stop the execution of the caller
-        throw error;
-      }
-      const { secure, host, port } = options.urlOptions || defaultUrlOptions;
-
-      fetchConnectionMetadata = async (abortSignal: AbortSignal) => {
-        try {
-          const { token, aborted } = await fetchToken(abortSignal);
-          if (aborted || !token) {
-            return { error: FetchConnectionMetadataError.Aborted };
-          }
-          return {
-            token,
-            gurl: `ws${secure ? 's' : ''}://${host}:${port}`,
-            conmanURL: `http${secure ? 's' : ''}://${host}:${port}`,
-            error: null,
-          };
-        } catch (e) {
-          return {
-            error: e,
-          };
-        }
-      };
-    }
-
     if (this.destroyed) {
       const error = new Error('Client has been destroyed and cannot be re-used');
       this.onUnrecoverableError(error);
@@ -288,7 +250,6 @@ export class Client<Ctx extends unknown = null> {
     }
 
     this.connectOptions = {
-      fetchConnectionMetadata,
       timeout: 10000,
       ...options,
     };

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,16 +53,11 @@ export interface UrlOptions {
 /**
  * Connection options supplied to [[Client.open]]
  *
- * The only required option is `fetchConnectionMetadata` (falling back to
- * `fetchToken`), all others are optional and will use defaults.
- *
- * TODO(lhchavez): Once the migration is done, drop `fetchToken` and only use
- * `fetchConnectionMetadata`.
+ * The only required option is `fetchConnectionMetadata`, all others are
+ * optional and will use defaults.
  */
 export interface OpenOptions<Ctx> extends Partial<ConnectOptions<Ctx>> {
-  fetchToken?: (
-    abortSignal: AbortSignal,
-  ) => Promise<{ token: null; aborted: true } | { token: string; aborted: false }>;
+  fetchConnectionMetadata: (abortSignal: AbortSignal) => Promise<FetchConnectionMetadataResult>;
   urlOptions?: UrlOptions;
   context: Ctx;
 }


### PR DESCRIPTION
Why
===

https://replit.slack.com/archives/C3AA56MFS/p1621480057153900?thread_ts=1621477611.143800&cid=C3AA56MFS

We want to make Goval incidents not also bring the web down.

What changed
============

Now that we've been running with `fetchConnectionMetadata` for a while,
let's drop support for `fetchToken`.

Test plan
=========

```shell
yarn test
```