### PR TITLE
Make sure to send close requests before opening channels

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -618,7 +618,6 @@ test('closing client maintains openChannel requests', (done) => {
 
 test('client rejects opening same channel twice', () => {
   const client = new Client();
-  client.setUnrecoverableErrorHandler(() => {});
 
   const name = Math.random().toString();
   client.openChannel({ name, service: 'exec' }, () => {});
@@ -630,7 +629,6 @@ test('client rejects opening same channel twice', () => {
 
 test('allows opening channel with the same name after closing others and client is disconnected', (done) => {
   const client = new Client();
-  client.setUnrecoverableErrorHandler(done);
 
   const name = Math.random().toString();
 
@@ -665,7 +663,6 @@ test('allows opening channel with the same name after closing others and client 
 
 test('allows opening channel with the same name after others are closing others and client is connected', (done) => {
   const client = new Client();
-  client.setUnrecoverableErrorHandler(done);
 
   client.open(
     {

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -634,12 +634,16 @@ test('allows opening channel with the same name after closing others and client 
 
   const name = Math.random().toString();
 
-  const close = client.openChannel({ name, service: 'exec' }, () => {});
+  let calledFirstWithError = false;
+  const close = client.openChannel({ name, service: 'exec' }, ({ error }) => {
+    calledFirstWithError = Boolean(error);
+  });
 
   close();
   // open same name synchronously
   client.openChannel({ name, service: 'exec' }, ({ channel }) => {
     expect(channel).toBeTruthy();
+    expect(calledFirstWithError).toBeTruthy();
     client.close();
 
     done();

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -3,6 +3,7 @@
 import type { FetchConnectionMetadataResult } from '../types';
 import { Client, FetchConnectionMetadataError } from '..';
 import { getWebSocketClass } from '../util/helpers';
+import { Channel } from '../channel';
 
 // eslint-disable-next-line
 const genConnectionMetadata = require('../../debug/genConnectionMetadata');
@@ -564,7 +565,7 @@ test('openChannel before open', (done) => {
   );
 });
 
-test('closing maintains openChannel requests', (done) => {
+test('closing client maintains openChannel requests', (done) => {
   const client = new Client();
 
   let first = true;
@@ -627,20 +628,21 @@ test('client rejects opening same channel twice', () => {
   }).toThrow();
 });
 
-test('allows opening channel with the same name while if others are closing', (done) => {
+test('allows opening channel with the same name after closing others and client is disconnected', (done) => {
   const client = new Client();
+  client.setUnrecoverableErrorHandler(done);
 
   const name = Math.random().toString();
 
-  const close = client.openChannel({ name, service: 'exec' }, () => {
-    setTimeout(() => {
-      close();
-      // open same name synchronously
-      client.openChannel({ name, service: 'exec' }, ({ channel }) => {
-        expect(channel).toBeTruthy();
-        client.close();
-      });
-    });
+  const close = client.openChannel({ name, service: 'exec' }, () => {});
+
+  close();
+  // open same name synchronously
+  client.openChannel({ name, service: 'exec' }, ({ channel }) => {
+    expect(channel).toBeTruthy();
+    client.close();
+
+    done();
   });
 
   client.open(
@@ -653,8 +655,77 @@ test('allows opening channel with the same name while if others are closing', (d
       WebSocketClass: WebSocket,
       context: null,
     },
-    () => {
-      done();
+    () => {},
+  );
+});
+
+test('allows opening channel with the same name after others are closing others and client is connected', (done) => {
+  const client = new Client();
+  client.setUnrecoverableErrorHandler(done);
+
+  client.open(
+    {
+      fetchConnectionMetadata: () =>
+        Promise.resolve({
+          ...genConnectionMetadata(),
+          error: null,
+        }),
+      WebSocketClass: WebSocket,
+      context: null,
+    },
+    ({ error }) => {
+      if (error) {
+        done(error);
+
+        return () => {};
+      }
+
+      const name = Math.random().toString();
+
+      let firstChannel: Channel;
+      const close = client.openChannel({ name, service: 'exec' }, ({ channel }) => {
+        expect(channel).toBeTruthy();
+
+        if (!channel) {
+          throw new Error('apease typescript');
+        }
+
+        firstChannel = channel;
+
+        expect(firstChannel.status).toEqual('closing');
+      });
+
+      // Close immediately
+      close();
+
+      // open same name synchronously
+      const close2 = client.openChannel({ name, service: 'exec' }, ({ channel: secondChannel }) => {
+        // ensure first channel opens
+        expect(firstChannel).toBeTruthy();
+        expect(secondChannel).toBeTruthy();
+        expect(secondChannel?.status).toEqual('open');
+        expect(secondChannel).not.toEqual(firstChannel);
+
+        // After the channel is opened close the current channel and open a new one
+        close2();
+        expect(secondChannel?.status).toEqual('closing');
+        const close3 = client.openChannel(
+          { name, service: 'exec' },
+          ({ channel: finalChannel }) => {
+            expect(finalChannel).toBeTruthy();
+            expect(finalChannel?.status).toEqual('open');
+            expect(finalChannel).not.toEqual(firstChannel);
+            expect(finalChannel).not.toEqual(secondChannel);
+
+            close3();
+
+            client.close();
+            done();
+          },
+        );
+      });
+
+      return () => {};
     },
   );
 });

--- a/src/client.ts
+++ b/src/client.ts
@@ -328,11 +328,11 @@ export class Client<Ctx extends unknown = null> {
    *```
    */
   public openChannel = (options: ChannelOptions<Ctx>, cb: OpenChannelCb<Ctx>): (() => void) => {
-    const sameNameChanRequests = this.channelRequests.filter(
-      (cr) => cr.options.name === options.name,
-    );
+    const sameNameChanRequests = options.name
+      ? this.channelRequests.filter((cr) => cr.options.name === options.name)
+      : [];
 
-    if (options.name && sameNameChanRequests.some((cr) => !cr.closeRequested)) {
+    if (sameNameChanRequests.some((cr) => !cr.closeRequested)) {
       // The protocol forbids opening a channel with the same name, so we're gonna prevent that early
       // so that we can give the caller a good stack trace to work with.
       // If the channel is queued for closure or is closing then we allow it.

--- a/src/client.ts
+++ b/src/client.ts
@@ -386,13 +386,11 @@ export class Client<Ctx extends unknown = null> {
         if (this.connectionState !== ConnectionState.CONNECTED) {
           this.channelRequests = this.channelRequests.filter((cr) => cr !== channelRequest);
 
-          if (this.connectOptions) {
-            channelRequest.openChannelCb({
-              error: new Error('Channel closed before opening'),
-              channel: null,
-              context: this.connectOptions.context,
-            });
-          }
+          channelRequest.openChannelCb({
+            error: new Error('Channel closed before opening'),
+            channel: null,
+            context: this.connectOptions ? this.connectOptions.context : null,
+          });
         }
 
         return;
@@ -1323,17 +1321,11 @@ export class Client<Ctx extends unknown = null> {
       } else if (!willChannelReconnect) {
         // channel won't reconnect and was never opened
         // we'll call the open channel callback with an error
-        if (this.connectOptions) {
-          channelRequest.openChannelCb({
-            channel: null,
-            error: new Error('Failed to open'),
-            context: this.connectOptions.context,
-          });
-        } else if (closeResult.closeReason !== ClientCloseReason.Error) {
-          this.onUnrecoverableError(new Error('Expected connectionOptions'));
-
-          return;
-        }
+        channelRequest.openChannelCb({
+          channel: null,
+          error: new Error('Failed to open'),
+          context: this.connectOptions ? this.connectOptions.context : null,
+        });
       }
 
       const { cleanupCb, closeRequested } = channelRequest;
@@ -1390,11 +1382,11 @@ export class Client<Ctx extends unknown = null> {
       });
       this.chan0CleanupCb = null;
     } else if (!willClientReconnect) {
-      if (this.chan0Cb && this.connectOptions) {
+      if (this.chan0Cb) {
         this.chan0Cb({
           channel: null,
           error: new Error('Failed to open'),
-          context: this.connectOptions.context,
+          context: this.connectOptions ? this.connectOptions.context : null,
         });
       } else if (closeResult.closeReason !== ClientCloseReason.Error) {
         // if we got here as a result of an error we're not gonna call onUnrecoverableError again

--- a/src/client.ts
+++ b/src/client.ts
@@ -629,9 +629,9 @@ export class Client<Ctx extends unknown = null> {
     // Next up: we will check if there are any channels with the same name
     // that are queued up for opening. We have defered the opening of the channel
     // until after the current open one closes (see `openChannel`) because the
-    // protocol doesn't allow opening multiple channels with the same name.
+    // protocol doesn't allow opening multiple channels with the same name
 
-    if (!channelRequest.options.name || this.connectionState === ConnectionState.CONNECTED) {
+    if (!channelRequest.options.name || this.connectionState !== ConnectionState.CONNECTED) {
       return;
     }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -328,13 +328,14 @@ export class Client<Ctx extends unknown = null> {
    *```
    */
   public openChannel = (options: ChannelOptions<Ctx>, cb: OpenChannelCb<Ctx>): (() => void) => {
-    if (
-      options.name &&
-      this.channelRequests.some((cr) => !cr.closeRequested && cr.options.name === options.name)
-    ) {
+    const sameNameChanRequests = this.channelRequests.filter(
+      (cr) => cr.options.name === options.name,
+    );
+
+    if (options.name && sameNameChanRequests.some((cr) => !cr.closeRequested)) {
       // The protocol forbids opening a channel with the same name, so we're gonna prevent that early
-      // so that we can give the caller a good stack trace to work with. If the channel is queued for
-      // closure then we allow it.
+      // so that we can give the caller a good stack trace to work with.
+      // If the channel is queued for closure or is closing then we allow it.
       const error = new Error(`Channel with name ${options.name} already opened`);
       this.onUnrecoverableError(error);
 
@@ -363,23 +364,36 @@ export class Client<Ctx extends unknown = null> {
 
     if (this.connectionState === ConnectionState.CONNECTED) {
       // We're connected, open channel. Otherwise we'll open the channel once we connect
-      this.requestOpenChannel(channelRequest);
+      if (!sameNameChanRequests.length) {
+        // There are no channels queued for closure we have to open it here
+        // otherwise, after existing channels are done closing
+        this.requestOpenChannel(channelRequest);
+      }
     }
 
-    let calledClose = false;
     const closeChannel = () => {
-      if (calledClose) {
+      if (channelRequest.closeRequested) {
         return;
       }
 
-      calledClose = true;
       channelRequest.closeRequested = true;
 
       if (!channelRequest.isOpen) {
-        // Channel is not open, let's just remove it from our list.
-        // If there's an inflight open request then we'll be sending a close
-        // request right after it's done opening
-        this.channelRequests = this.channelRequests.filter((cr) => cr !== channelRequest);
+        // Channel is not open and we're not connected, let's just remove it from our list.
+        // If we're connected, it means there's an inflight open request
+        // then we'll be sending a close request right after it's done opening
+        // so that we can use the channel ID when closing
+        if (this.connectionState !== ConnectionState.CONNECTED) {
+          this.channelRequests = this.channelRequests.filter((cr) => cr !== channelRequest);
+
+          if (this.connectOptions) {
+            channelRequest.openChannelCb({
+              error: new Error('Channel closed before opening'),
+              channel: null,
+              context: this.connectOptions.context,
+            });
+          }
+        }
 
         return;
       }
@@ -426,7 +440,7 @@ export class Client<Ctx extends unknown = null> {
 
     this.debug({
       type: 'breadcrumb',
-      message: 'handleOpenChannel',
+      message: 'requestOpenChannel',
       data: {
         name: options.name,
         service,
@@ -506,17 +520,20 @@ export class Client<Ctx extends unknown = null> {
       // openChannelCb and once here.
       const { closeRequested } = channelRequest;
 
+      if (closeRequested) {
+        // While we're opening the channel, we got a request to close this channel
+        // let's take care of that and request a close.
+        // The reason we call it before `openChannelCb`
+        // is just to make sure that channel has a status
+        // of `closing`
+        this.requestCloseChannel(channelRequest);
+      }
+
       (channelRequest as ChannelRequest<Ctx>).cleanupCb = openChannelCb({
         channel,
         error: null,
         context: this.connectOptions.context,
       });
-
-      if (closeRequested) {
-        // While we're opening the channel, we got a request to close this channel
-        // let's take care of that and request a close
-        this.requestCloseChannel(channelRequest);
-      }
     });
   };
 
@@ -612,6 +629,20 @@ export class Client<Ctx extends unknown = null> {
     if (channelRequest.cleanupCb) {
       channelRequest.cleanupCb({ initiator: 'channel', willReconnect: false });
     }
+
+    if (!channelRequest.options.name) {
+      return;
+    }
+
+    const nextRequest = this.channelRequests.find(
+      (cr) => cr.options.name === channelRequest.options.name,
+    );
+
+    if (!nextRequest) {
+      return;
+    }
+
+    this.requestOpenChannel(nextRequest);
   };
 
   /**
@@ -1305,7 +1336,7 @@ export class Client<Ctx extends unknown = null> {
         }
       }
 
-      const { cleanupCb } = channelRequest;
+      const { cleanupCb, closeRequested } = channelRequest;
 
       // Re-set the channel request's state
       // TODO we should stop relying on mutating the same channelrequest
@@ -1322,6 +1353,12 @@ export class Client<Ctx extends unknown = null> {
           initiator: 'client',
           willReconnect: willChannelReconnect,
         });
+      }
+
+      if (closeRequested || channelRequest.closeRequested) {
+        // Channel closed earlier but we couldn't process the close request
+        // or closed during cleanupCb that we just called
+        this.channelRequests = this.channelRequests.filter((cr) => cr !== channelRequest);
       }
     });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -130,7 +130,7 @@ export interface ChannelOptions<Ctx> {
 export type OpenChannelCb<Ctx> = (
   res:
     | { error: null; channel: Channel; context: Ctx }
-    | { error: Error; channel: null; context: Ctx },
+    | { error: Error; channel: null; context: Ctx | null },
 ) => void | ((reason: ChannelCloseReason) => void);
 
 export interface RequestResult extends api.Command {


### PR DESCRIPTION
Why
===

https://github.com/replit/crosis/pull/87 `(Allow opening channels with the same name if others are closing)` was not implemented correctly. The test there only works because the client is not connected. If the client is already connected and we try to open a channel after calling `close` then try to open the channel again it will lead to a protocol error. This happens because the client will send a new open request before it sends a request to close the current channel, the main struggle is that you actually need the first channel to finish opening so you can use the provided ID to close it. 

What changed
============
- If there are channels with the same name that are in the process of closing, we don't request to open the channel immediately from the `openChannel` call.
- After a channel is done closing, we take the next open request from the top of the queue and open it.

A couple of notes. We will still call the open channel callback, but the channel's state will be `closing`, you can still listen to commands (`channel.onCommand`) as the client can be receiving commands for that channel while it's in the process of closing it. We also do not collapse open/close requests, if the client is open, we will always open the channel then send a close request, I decided to do this from a simplicity standpoint, both from a user perspective and implementation.

N.B There are a cleaner ways of implementing this whole thing, but they require refactoring the client and it's not worth it. 

Test plan
=========
I added 2 tests, let me know if they need commenting, but they should cover all new and old codepaths for opening channel with the same name.