### PR TITLE
Unset connection metadata when close is intentional

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -641,7 +641,9 @@ test('closing client maintains openChannel requests', (done) => {
             WebSocketClass: WebSocket,
             context: null,
           },
-          () => {},
+          () => () => {
+            done();
+          },
         );
       }, 200);
     } else {
@@ -662,15 +664,14 @@ test('closing client maintains openChannel requests', (done) => {
     ({ channel }) => {
       expect(channel).toBeTruthy();
 
-      return () => {
-        done();
-      };
+      return () => {};
     },
   );
 });
 
 test('client rejects opening same channel twice', () => {
   const client = new Client();
+  client.setUnrecoverableErrorHandler(() => {});
 
   const name = Math.random().toString();
   client.openChannel({ name, service: 'exec' }, () => {});

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -171,6 +171,59 @@ test('client retries and caches tokens', (done) => {
   );
 });
 
+test('client requests new connection metadata after intentional close', (done) => {
+  const client = new Client();
+
+  client.open(
+    {
+      fetchConnectionMetadata: () =>
+        Promise.resolve({
+          ...genConnectionMetadata(),
+          error: null,
+        }),
+      WebSocketClass: WebSocket,
+      context: null,
+    },
+    ({ channel, error }) => {
+      expect(channel?.status).toBe('open');
+      expect(error).toEqual(null);
+
+      client.close();
+
+      return () => {
+        // Gotta open in a timeout, opening in a tight loop makes it loop forever
+        setTimeout(() => {
+          let didCallFetchConnectionMetadata = false;
+          client.open(
+            {
+              fetchConnectionMetadata: () => {
+                didCallFetchConnectionMetadata = true;
+                return Promise.resolve({
+                  ...genConnectionMetadata(),
+                  error: null,
+                });
+              },
+              WebSocketClass: WebSocket,
+              context: null,
+            },
+            ({ channel: c2, error: e2 }) => {
+              expect(c2?.status).toBe('open');
+              expect(e2).toEqual(null);
+              expect(didCallFetchConnectionMetadata).toBeTruthy();
+
+              client.close();
+
+              return () => {
+                done();
+              };
+            },
+          );
+        });
+      };
+    },
+  );
+});
+
 test('channel closing itself when client willReconnect', (done) => {
   let disconnectTriggered = false;
   let clientOpenCount = 0;

--- a/src/client.ts
+++ b/src/client.ts
@@ -673,6 +673,10 @@ export class Client<Ctx extends unknown = null> {
       this.fetchTokenAbortController = null;
     }
 
+    // If the close is intentional, let's unset the metadata, the client
+    // may be re-used to connect to another repl
+    this.connectionMetadata = null;
+
     this.handleClose({ closeReason: ClientCloseReason.Intentional });
   };
 


### PR DESCRIPTION
Why
===
We had this guarantee that we will get new connection metadata after each disconnect, intentional or not. Now we always keep it cached, unless there's a specific websocket error.

I _think_  some parts of the website rely on the old behavior for intentional closes, the hint is provided by this code here https://github.com/replit/repl-it-web/blob/master/app/services/container/index.ts#L358-L361. More specifically, I think the anonymous language page uses this.

What changed
============
As the title said.

Test plan
=========
I should probably add a test, brb
