### PR TITLE
Add a way to register more than one debug callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+#### v7.1.1
+
+Added Client.addDebugFunc that makes it possible to have more than one debug callback.
+
 #### v7.1.0
 
 Reverted changes from v7.0.0 which caused issues in Replit. The client now always gets a new token when it reconnects and downgrades to polling if it didn't receive a valid api command.

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -131,7 +131,7 @@ test.skip('client retries and caches tokens', (done) => {
   const fetchConnectionMetadata = jest.fn();
 
   let reconnectCount = 0;
-  client.setDebugFunc((log) => {
+  client.addDebugFunc((log) => {
     if (log.type !== 'breadcrumb' || log.message !== 'retrying') {
       return;
     }
@@ -918,7 +918,7 @@ test('client is closed while reconnecting', (done) => {
   const onOpen = jest.fn();
 
   const client = new Client();
-  client.setDebugFunc((log) => {
+  client.addDebugFunc((log) => {
     if (log.type === 'breadcrumb' && log.message === 'reconnecting') {
       setTimeout(() => {
         client.close();
@@ -958,7 +958,7 @@ test('client is closed while reconnecting', (done) => {
 
 test('closing before ever connecting', (done) => {
   const client = new Client();
-  client.setDebugFunc((log) => {
+  client.addDebugFunc((log) => {
     if (log.type === 'breadcrumb' && log.message === 'connecting') {
       setTimeout(() => {
         client.close();
@@ -1016,7 +1016,7 @@ test('fallback to polling', (done) => {
   expect(getWebSocketClass(WebsocketThatNeverConnects)).toEqual(WebsocketThatNeverConnects);
 
   let didLogFallback = false;
-  client.setDebugFunc((log) => {
+  client.addDebugFunc((log) => {
     if (log.type === 'breadcrumb' && log.message === 'polling fallback') {
       didLogFallback = true;
     }


### PR DESCRIPTION
Why
===

It's useful to have more than one callback at a time. For example, one for Sentry breadcrumbs reporting, the other one for debug panel or dumping logs to a text file in test environment.

What changed
============

Added new `addDebugFunc` method that returns a cleanup function. The callbacks are stored in a plan array for simplicity and portability — didn't want to depend on `EventEmitter` or `Map`.

The old `setDebugFunc` API still works.

Test plan
=========

👀 
