### PR TITLE
Revert "Allow recycling of connection metadata upon reconnects (#96)"

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -821,85 +821,81 @@ export class Client<Ctx extends unknown = null> {
     });
     this.channels[0] = chan0;
 
-    if (this.connectionMetadata === null) {
-      if (this.fetchTokenAbortController) {
-        this.onUnrecoverableError(new Error('Expected fetchTokenAbortController to be null'));
+    if (this.fetchTokenAbortController) {
+      this.onUnrecoverableError(new Error('Expected fetchTokenAbortController to be null'));
 
-        return;
-      }
+      return;
+    }
 
-      const abortController = new AbortController();
-      this.fetchTokenAbortController = abortController;
+    const abortController = new AbortController();
+    this.fetchTokenAbortController = abortController;
 
-      let connectionMetadataFetchResult;
-      try {
-        connectionMetadataFetchResult = await this.connectOptions.fetchConnectionMetadata(
-          abortController.signal,
-        );
-      } catch (e) {
-        this.onUnrecoverableError(e);
+    let connectionMetadataFetchResult;
+    try {
+      connectionMetadataFetchResult = await this.connectOptions.fetchConnectionMetadata(
+        abortController.signal,
+      );
+    } catch (e) {
+      this.onUnrecoverableError(e);
 
-        return;
-      }
+      return;
+    }
 
-      this.fetchTokenAbortController = null;
+    this.fetchTokenAbortController = null;
 
-      const connectionMetadata = connectionMetadataFetchResult;
-      const aborted = connectionMetadata.error === FetchConnectionMetadataError.Aborted;
+    const connectionMetadata = connectionMetadataFetchResult;
+    const aborted = connectionMetadata.error === FetchConnectionMetadataError.Aborted;
 
-      if (abortController.signal.aborted !== aborted) {
-        // the aborted return value and the abort signal should be equivalent
-        if (abortController.signal.aborted) {
-          // In cases where our abort signal has been called means `client.close` was called
-          // that means we shouldn't be calling `handleConnectError` because chan0Cb is null!
-          this.onUnrecoverableError(
-            new Error(
-              'Expected abort returned from fetchConnectionMetadata to be truthy when the controller aborts',
-            ),
-          );
-
-          return;
-        }
-
-        // the user shouldn't return abort without the abort signal being called, if aborting is desired
-        // client.close should be called
+    if (abortController.signal.aborted !== aborted) {
+      // the aborted return value and the abort signal should be equivalent
+      if (abortController.signal.aborted) {
+        // In cases where our abort signal has been called means `client.close` was called
+        // that means we shouldn't be calling `handleConnectError` because chan0Cb is null!
         this.onUnrecoverableError(
-          new Error('Abort should only be truthy returned when the abort signal is triggered'),
+          new Error(
+            'Expected abort returned from fetchConnectionMetadata to be truthy when the controller aborts',
+          ),
         );
 
         return;
       }
 
-      if (connectionMetadata.error === FetchConnectionMetadataError.Aborted) {
-        // Just return. The user called `client.close leading to a connectionMetadata abort
-        // chan0Cb will be called with with an error Channel close, no need to do anything here.
-        return;
-      }
+      // the user shouldn't return abort without the abort signal being called, if aborting is desired
+      // client.close should be called
+      this.onUnrecoverableError(
+        new Error('Abort should only be truthy returned when the abort signal is triggered'),
+      );
 
-      if (connectionMetadata.error === FetchConnectionMetadataError.Retriable) {
-        this.retryConnect({
-          tryCount: tryCount + 1,
-          websocketFailureCount,
-          chan0,
-          error: new Error('Retriable error'),
-        });
+      return;
+    }
 
-        return;
-      }
+    if (connectionMetadata.error === FetchConnectionMetadataError.Aborted) {
+      // Just return. The user called `client.close leading to a connectionMetadata abort
+      // chan0Cb will be called with with an error Channel close, no need to do anything here.
+      return;
+    }
 
-      if (this.connectionState !== ConnectionState.CONNECTING) {
-        this.onUnrecoverableError(new Error('Client was closed before connecting'));
+    if (connectionMetadata.error === FetchConnectionMetadataError.Retriable) {
+      this.retryConnect({
+        tryCount: tryCount + 1,
+        websocketFailureCount,
+        chan0,
+        error: new Error('Retriable error'),
+      });
 
-        return;
-      }
+      return;
+    }
 
-      if (connectionMetadata.error) {
-        this.onUnrecoverableError(connectionMetadata.error);
+    if (this.connectionState !== ConnectionState.CONNECTING) {
+      this.onUnrecoverableError(new Error('Client was closed before connecting'));
 
-        return;
-      }
+      return;
+    }
 
-      this.connectionMetadata = connectionMetadata;
+    if (connectionMetadata.error) {
+      this.onUnrecoverableError(connectionMetadata.error);
+
+      return;
     }
 
     if (websocketFailureCount === 3) {
@@ -914,23 +910,18 @@ export class Client<Ctx extends unknown = null> {
     const WebSocketClass = isPolling
       ? EIOCompat
       : getWebSocketClass(this.connectOptions.WebSocketClass);
-    const connStr = getConnectionStr(this.connectionMetadata, isPolling);
+    const connStr = getConnectionStr(connectionMetadata, isPolling);
     const ws = new WebSocketClass(connStr);
 
     ws.binaryType = 'arraybuffer';
     ws.onmessage = this.onSocketMessage;
     this.ws = ws;
+    this.connectionMetadata = connectionMetadata;
 
     // We'll use this to determine whether or not we should consider the next
     // failure a websocket failure and fallback to polling. If we were able to
     // pass the handshake phase at some point, then websockets work fine.
     let didWebsocketsWork = false;
-
-    // We'll use this to determine whether or not we should consider the next
-    // polling implementation failure to require a fresh metadata. If we were
-    // able to receive any messages on channel 0, then the current metadata
-    // should still be valid.
-    let didReceiveAnyCommand = false;
 
     /**
      * Failure can happen due to a number of reasons
@@ -954,26 +945,11 @@ export class Client<Ctx extends unknown = null> {
     /**
      * Abrupt socket closures should report failed
      */
-    ws.onclose = (event: CloseEvent | Event) => {
+    ws.onclose = () => {
       if (!onFailed) {
         this.onUnrecoverableError(new Error('Got websocket closure but no `onFailed` cb'));
 
         return;
-      }
-
-      if (WebSocketClass === EIOCompat) {
-        if (!didReceiveAnyCommand) {
-          // The polling implementation doesn't convey the Websocket close
-          // event. Let's assume that we need to request a new token.
-          this.connectionMetadata = null;
-        }
-      } else if ('code' in event) {
-        const closeEvent = <CloseEvent>event;
-        const closeCodePolicyViolation = 1008;
-        if (closeEvent.code === closeCodePolicyViolation) {
-          // This means that the token was rejected. We need to fetch another one.
-          this.connectionMetadata = null;
-        }
       }
 
       onFailed(new Error('WebSocket closed before we got READY'));
@@ -1043,7 +1019,6 @@ export class Client<Ctx extends unknown = null> {
      * and connection should be dropped
      */
     const unlistenChan0 = chan0.onCommand((cmd: api.Command) => {
-      didReceiveAnyCommand = true;
       // Everytime we get a message on channel0
       // we will reset the timeout
       resetTimeout();
@@ -1440,6 +1415,7 @@ export class Client<Ctx extends unknown = null> {
     }
 
     this.ws = null;
+    this.connectionMetadata = null;
 
     ws.onmessage = null;
     ws.onclose = null;


### PR DESCRIPTION
 https://app.asana.com/0/0/1200554387833013/1200562676375228/f

It's not a strict revert, I kept a test in and added a test to make sure we're fetching a new token for unintentional disconnects.