### PR TITLE
Reland "Allow recycling of connection metadata upon reconnects (#96)"

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -259,6 +259,7 @@ export class Client<Ctx extends unknown = null> {
 
     this.connectOptions = {
       timeout: 10000,
+      reuseConnectionMetadata: false,
       ...options,
     };
 
@@ -860,81 +861,85 @@ export class Client<Ctx extends unknown = null> {
     });
     this.channels[0] = chan0;
 
-    if (this.fetchTokenAbortController) {
-      this.onUnrecoverableError(new Error('Expected fetchTokenAbortController to be null'));
+    if (!this.connectOptions.reuseConnectionMetadata || this.connectionMetadata === null) {
+      if (this.fetchTokenAbortController) {
+        this.onUnrecoverableError(new Error('Expected fetchTokenAbortController to be null'));
 
-      return;
-    }
+        return;
+      }
 
-    const abortController = new AbortController();
-    this.fetchTokenAbortController = abortController;
+      const abortController = new AbortController();
+      this.fetchTokenAbortController = abortController;
 
-    let connectionMetadataFetchResult;
-    try {
-      connectionMetadataFetchResult = await this.connectOptions.fetchConnectionMetadata(
-        abortController.signal,
-      );
-    } catch (e) {
-      this.onUnrecoverableError(e);
+      let connectionMetadataFetchResult;
+      try {
+        connectionMetadataFetchResult = await this.connectOptions.fetchConnectionMetadata(
+          abortController.signal,
+        );
+      } catch (e) {
+        this.onUnrecoverableError(e);
 
-      return;
-    }
+        return;
+      }
 
-    this.fetchTokenAbortController = null;
+      this.fetchTokenAbortController = null;
 
-    const connectionMetadata = connectionMetadataFetchResult;
-    const aborted = connectionMetadata.error === FetchConnectionMetadataError.Aborted;
+      const connectionMetadata = connectionMetadataFetchResult;
+      const aborted = connectionMetadata.error === FetchConnectionMetadataError.Aborted;
 
-    if (abortController.signal.aborted !== aborted) {
-      // the aborted return value and the abort signal should be equivalent
-      if (abortController.signal.aborted) {
-        // In cases where our abort signal has been called means `client.close` was called
-        // that means we shouldn't be calling `handleConnectError` because chan0Cb is null!
+      if (abortController.signal.aborted !== aborted) {
+        // the aborted return value and the abort signal should be equivalent
+        if (abortController.signal.aborted) {
+          // In cases where our abort signal has been called means `client.close` was called
+          // that means we shouldn't be calling `handleConnectError` because chan0Cb is null!
+          this.onUnrecoverableError(
+            new Error(
+              'Expected abort returned from fetchConnectionMetadata to be truthy when the controller aborts',
+            ),
+          );
+
+          return;
+        }
+
+        // the user shouldn't return abort without the abort signal being called, if aborting is desired
+        // client.close should be called
         this.onUnrecoverableError(
-          new Error(
-            'Expected abort returned from fetchConnectionMetadata to be truthy when the controller aborts',
-          ),
+          new Error('Abort should only be truthy returned when the abort signal is triggered'),
         );
 
         return;
       }
 
-      // the user shouldn't return abort without the abort signal being called, if aborting is desired
-      // client.close should be called
-      this.onUnrecoverableError(
-        new Error('Abort should only be truthy returned when the abort signal is triggered'),
-      );
+      if (connectionMetadata.error === FetchConnectionMetadataError.Aborted) {
+        // Just return. The user called `client.close leading to a connectionMetadata abort
+        // chan0Cb will be called with with an error Channel close, no need to do anything here.
+        return;
+      }
 
-      return;
-    }
+      if (connectionMetadata.error === FetchConnectionMetadataError.Retriable) {
+        this.retryConnect({
+          tryCount: tryCount + 1,
+          websocketFailureCount,
+          chan0,
+          error: new Error('Retriable error'),
+        });
 
-    if (connectionMetadata.error === FetchConnectionMetadataError.Aborted) {
-      // Just return. The user called `client.close leading to a connectionMetadata abort
-      // chan0Cb will be called with with an error Channel close, no need to do anything here.
-      return;
-    }
+        return;
+      }
 
-    if (connectionMetadata.error === FetchConnectionMetadataError.Retriable) {
-      this.retryConnect({
-        tryCount: tryCount + 1,
-        websocketFailureCount,
-        chan0,
-        error: new Error('Retriable error'),
-      });
+      if (this.connectionState !== ConnectionState.CONNECTING) {
+        this.onUnrecoverableError(new Error('Client was closed before connecting'));
 
-      return;
-    }
+        return;
+      }
 
-    if (this.connectionState !== ConnectionState.CONNECTING) {
-      this.onUnrecoverableError(new Error('Client was closed before connecting'));
+      if (connectionMetadata.error) {
+        this.onUnrecoverableError(connectionMetadata.error);
 
-      return;
-    }
+        return;
+      }
 
-    if (connectionMetadata.error) {
-      this.onUnrecoverableError(connectionMetadata.error);
-
-      return;
+      this.connectionMetadata = connectionMetadata;
     }
 
     if (websocketFailureCount === 3) {
@@ -949,18 +954,23 @@ export class Client<Ctx extends unknown = null> {
     const WebSocketClass = isPolling
       ? EIOCompat
       : getWebSocketClass(this.connectOptions.WebSocketClass);
-    const connStr = getConnectionStr(connectionMetadata, isPolling);
+    const connStr = getConnectionStr(this.connectionMetadata, isPolling);
     const ws = new WebSocketClass(connStr);
 
     ws.binaryType = 'arraybuffer';
     ws.onmessage = this.onSocketMessage;
     this.ws = ws;
-    this.connectionMetadata = connectionMetadata;
 
     // We'll use this to determine whether or not we should consider the next
     // failure a websocket failure and fallback to polling. If we were able to
     // pass the handshake phase at some point, then websockets work fine.
     let didWebsocketsWork = false;
+
+    // We'll use this to determine whether or not we should consider the next
+    // polling implementation failure to require a fresh metadata. If we were
+    // able to receive any messages on channel 0, then the current metadata
+    // should still be valid.
+    let didReceiveAnyCommand = false;
 
     /**
      * Failure can happen due to a number of reasons
@@ -984,11 +994,26 @@ export class Client<Ctx extends unknown = null> {
     /**
      * Abrupt socket closures should report failed
      */
-    ws.onclose = () => {
+    ws.onclose = (event: CloseEvent | Event) => {
       if (!onFailed) {
         this.onUnrecoverableError(new Error('Got websocket closure but no `onFailed` cb'));
 
         return;
+      }
+
+      if (WebSocketClass === EIOCompat) {
+        if (!didReceiveAnyCommand) {
+          // The polling implementation doesn't convey the Websocket close
+          // event. Let's assume that we need to request a new token.
+          this.connectionMetadata = null;
+        }
+      } else if ('code' in event) {
+        const closeEvent = <CloseEvent>event;
+        const closeCodePolicyViolation = 1008;
+        if (closeEvent.code === closeCodePolicyViolation) {
+          // This means that the token was rejected. We need to fetch another one.
+          this.connectionMetadata = null;
+        }
       }
 
       onFailed(new Error('WebSocket closed before we got READY'));
@@ -1058,6 +1083,7 @@ export class Client<Ctx extends unknown = null> {
      * and connection should be dropped
      */
     const unlistenChan0 = chan0.onCommand((cmd: api.Command) => {
+      didReceiveAnyCommand = true;
       // Everytime we get a message on channel0
       // we will reset the timeout
       resetTimeout();
@@ -1454,7 +1480,6 @@ export class Client<Ctx extends unknown = null> {
     }
 
     this.ws = null;
-    this.connectionMetadata = null;
 
     ws.onmessage = null;
     ws.onclose = null;

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,6 +42,7 @@ export interface ConnectOptions<Ctx> {
   timeout: number | null;
   WebSocketClass?: typeof WebSocket;
   context: Ctx;
+  reuseConnectionMetadata: boolean;
 }
 
 export interface UrlOptions {


### PR DESCRIPTION
Why
===

https://replit.slack.com/archives/C3AA56MFS/p1621480057153900?thread_ts=1621477611.143800&cid=C3AA56MFS

Getting new tokens every time we want to reconnect is slightly wasteful,
since most likely the token the clients have already are still valid.
Furthermore, during incidents where goval is unhappy, all the extra
retries will cause cascading failures due to all the attempts to re-get
tokens, which causes extra load to repl-it-web as well as Lore.

This change is better reviewed with [whitespace disabled :dark_sunglasses:](https://github.com/replit/crosis/pull/105/files?diff=split&w=1).

What changed
============

This is a mostly as-is reland of #96 (by cherry-picking that change, instead of reverting the revert).

This change now keeps the connection metadata across reconnects,
_unless_ goval explicitly tells crosis to fetch a new one. This happens
when goval accepts the connection and immediately closes it with the
Close Code 1008 (Policy Violation).

This time around, the `ConnectOptions` now receives a
`reuseConnectionMetadata` field, and will reuse tokens only when it's
set to `true`. This allows a flagged deployment.

Test plan
=========

```shell
yarn test
```