### PR TITLE
Allow polling host to be overridden

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -954,7 +954,7 @@ export class Client<Ctx extends unknown = null> {
     const WebSocketClass = isPolling
       ? EIOCompat
       : getWebSocketClass(this.connectOptions.WebSocketClass);
-    const connStr = getConnectionStr(this.connectionMetadata, isPolling);
+    const connStr = getConnectionStr(this.connectionMetadata, isPolling, this.connectOptions.pollingHost);
     const ws = new WebSocketClass(connStr);
 
     ws.binaryType = 'arraybuffer';

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,6 +43,7 @@ export interface ConnectOptions<Ctx> {
   WebSocketClass?: typeof WebSocket;
   context: Ctx;
   reuseConnectionMetadata: boolean;
+  pollingHost?: string;
 }
 
 export interface UrlOptions {

--- a/src/util/helpers.ts
+++ b/src/util/helpers.ts
@@ -57,7 +57,7 @@ export function getWebSocketClass(
 export function getConnectionStr(
   connectionMetadata: GovalMetadata,
   isPolling: boolean,
-  pollingHost: string | null,
+  pollingHost?: string,
 ): string {
   const gurl = urllib.parse(connectionMetadata.gurl);
   if (isPolling) {

--- a/src/util/helpers.ts
+++ b/src/util/helpers.ts
@@ -61,7 +61,7 @@ export function getConnectionStr(
 ): string {
   const gurl = urllib.parse(connectionMetadata.gurl);
   if (isPolling) {
-    const host = pollingHost || 'gp-v2.herokuapp.com';
+    const host = pollingHost ?? 'gp-v2.herokuapp.com';
     gurl.hostname = host;
     gurl.host = host;
     gurl.pathname = `/wsv2/${connectionMetadata.token}/${encodeURIComponent(

--- a/src/util/helpers.ts
+++ b/src/util/helpers.ts
@@ -61,7 +61,7 @@ export function getConnectionStr(
 ): string {
   const gurl = urllib.parse(connectionMetadata.gurl);
   if (isPolling) {
-    const host = pollingHost || 'gp-v2.replit.com';
+    const host = pollingHost || 'gp-v2.herokuapp.com';
     gurl.hostname = host;
     gurl.host = host;
     gurl.pathname = `/wsv2/${connectionMetadata.token}/${encodeURIComponent(

--- a/src/util/helpers.ts
+++ b/src/util/helpers.ts
@@ -54,11 +54,16 @@ export function getWebSocketClass(
 /**
  * Given connection metadata, creates a websocket connection string
  */
-export function getConnectionStr(connectionMetadata: GovalMetadata, isPolling: boolean): string {
+export function getConnectionStr(
+  connectionMetadata: GovalMetadata,
+  isPolling: boolean,
+  pollingHost: string | null,
+): string {
   const gurl = urllib.parse(connectionMetadata.gurl);
   if (isPolling) {
-    gurl.hostname = 'gp-v2.replit.com';
-    gurl.host = 'gp-v2.replit.com';
+    const host = pollingHost || 'gp-v2.replit.com';
+    gurl.hostname = host;
+    gurl.host = host;
     gurl.pathname = `/wsv2/${connectionMetadata.token}/${encodeURIComponent(
       connectionMetadata.gurl,
     )}`;

--- a/src/util/helpers.ts
+++ b/src/util/helpers.ts
@@ -57,8 +57,8 @@ export function getWebSocketClass(
 export function getConnectionStr(connectionMetadata: GovalMetadata, isPolling: boolean): string {
   const gurl = urllib.parse(connectionMetadata.gurl);
   if (isPolling) {
-    gurl.hostname = 'gp-v2.herokuapp.com';
-    gurl.host = 'gp-v2.herokuapp.com';
+    gurl.hostname = 'gp-v2.replit.com';
+    gurl.host = 'gp-v2.replit.com';
     gurl.pathname = `/wsv2/${connectionMetadata.token}/${encodeURIComponent(
       connectionMetadata.gurl,
     )}`;


### PR DESCRIPTION
Why
===

We're moving gp-v2 to gp-v2.replit.com. Being able to override the polling host in the client will make that migration easier.

What changed
============

Added `pollingHost` to `ConnectOptions`. We'll be able to override in client code and roll back changes without having to roll back this PR.

Test plan
=========

Block eval.global.replit.com via `/etc/hosts`, see requests still go to gp-v2.herokuapp.com.
