### PR TITLE
Update test token creation

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "engine.io-client": "^3.4.0"
   },
   "devDependencies": {
-    "@replit/protocol": "0.x.x",
+    "@replit/protocol": ">=0.2.45",
     "@types/engine.io-client": "^3.1.2",
     "@types/jest": "^25.2.3",
     "@types/node": "^12.7.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1302,10 +1302,10 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=
 
-"@replit/protocol@0.x.x":
-  version "0.2.18"
-  resolved "https://registry.yarnpkg.com/@replit/protocol/-/protocol-0.2.18.tgz#ac57637d9616699ac3b2250cecd9a1cd7214edb0"
-  integrity sha512-AtQvBtncBXQ1+ow7sI6H/HqJeZvwVu4pHFxDN2Z70yw20f9pP+ctd7L1qMKF9zGvM0+D2T4Tk8rvh8AvN24mrA==
+"@replit/protocol@>=0.2.45":
+  version "0.2.45"
+  resolved "https://registry.yarnpkg.com/@replit/protocol/-/protocol-0.2.45.tgz#976ae4fab3988618310e0f06d9d34025ec9706c2"
+  integrity sha512-igGTriCyz7VHu/CH1h1vcTWYQ+alsDLxyxKsvXQUI6WLKCp6Vi7Mb2rpexvT5nC5z0qaE/ZVz6xUwodIdp0kDw==
   dependencies:
     protobufjs "^6.10.2"
 


### PR DESCRIPTION
Why
===

Previously we were using a pretty old way to generate tokens. It has
drifted a bit from what is currently in production.

What changed
============

This change does a few things:

* Updates the dev-dependency on `@replit/protocol` to >=0.2.45 to get
  the latest and greatest protos.
* Stops expecting folks to provide the private key in PEM form. It now
  expects a base64-encoded ed25519 private key (which is just a few
  pretty long primes that fit on 64 bytes, lol).
* Updates the token trailer to match the latest in goval.

Test plan
=========

```yarn test```