### PR TITLE
Change the default polling host to `gp-v2.replit.com`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+#### v7.3.1
+
+Changed the default polling host to gp-v2.replit.com.
+
 #### v7.3.0
 
 Added an optional `pollingHost` field to `ConnectOptions`. This allows callers to override the polling host from gp-v2.herokuapp.com to something else when the polling fallback is used.

--- a/src/util/helpers.ts
+++ b/src/util/helpers.ts
@@ -61,7 +61,7 @@ export function getConnectionStr(
 ): string {
   const gurl = urllib.parse(connectionMetadata.gurl);
   if (isPolling) {
-    const host = pollingHost ?? 'gp-v2.herokuapp.com';
+    const host = pollingHost ?? 'gp-v2.replit.com';
     gurl.hostname = host;
     gurl.host = host;
     gurl.pathname = `/wsv2/${connectionMetadata.token}/${encodeURIComponent(


### PR DESCRIPTION
Why
===

We switched the host a few days ago, so it's better to reflect reality.

What changed
============

This changes the default polling host to `gp-v2.replit.com`.

Test plan
=========

:crossed_fingers:.