### PR TITLE
Stop giving a default `pollingHost` if unset

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -942,7 +942,7 @@ export class Client<Ctx extends unknown = null> {
       this.connectionMetadata = connectionMetadata;
     }
 
-    if (websocketFailureCount === 3) {
+    if (websocketFailureCount === 3 && this.connectOptions.pollingHost) {
       // Report that we fellback to polling
       this.debug({
         type: 'breadcrumb',
@@ -950,11 +950,14 @@ export class Client<Ctx extends unknown = null> {
       });
     }
 
-    const isPolling = websocketFailureCount >= 3;
+    const isPolling =
+        websocketFailureCount >= 3 && this.connectOptions.pollingHost;
     const WebSocketClass = isPolling
       ? EIOCompat
       : getWebSocketClass(this.connectOptions.WebSocketClass);
-    const connStr = getConnectionStr(this.connectionMetadata, isPolling, this.connectOptions.pollingHost);
+    const connStr = getConnectionStr(this.connectionMetadata,
+                                     isPolling ? this.connectOptions.pollingHost
+                                               : undefined);
     const ws = new WebSocketClass(connStr);
 
     ws.binaryType = 'arraybuffer';

--- a/src/util/helpers.ts
+++ b/src/util/helpers.ts
@@ -52,18 +52,17 @@ export function getWebSocketClass(
 }
 
 /**
- * Given connection metadata, creates a websocket connection string
+ * Given connection metadata, creates a websocket connection string. Will
+ * fallback to polling if `pollingHost` is provided.
  */
 export function getConnectionStr(
   connectionMetadata: GovalMetadata,
-  isPolling: boolean,
   pollingHost?: string,
 ): string {
   const gurl = urllib.parse(connectionMetadata.gurl);
-  if (isPolling) {
-    const host = pollingHost ?? 'gp-v2.replit.com';
-    gurl.hostname = host;
-    gurl.host = host;
+  if (pollingHost) {
+    gurl.hostname = pollingHost;
+    gurl.host = pollingHost;
     gurl.pathname = `/wsv2/${connectionMetadata.token}/${encodeURIComponent(
       connectionMetadata.gurl,
     )}`;


### PR DESCRIPTION
Why
===

Previously, we would provide a default of `gp-v2.replit.com` when
falling back to polling. But some folks might not _want_ to fallback to
polling.

What changed
============

This change now requires clients to explicitly set a `pollingHost` if
they want to fallback to *something*.

Test plan
=========

Added a test!