### PR TITLE
Provide channel service / name on the crosis logs

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -8,6 +8,16 @@ export class Channel {
   public id: number;
 
   /**
+   * The name of the channel.
+   */
+  public readonly name?: string;
+
+  /**
+   * The name of the service associated with the channel.
+   */
+  public readonly service?: string;
+
+  /**
    * The current connection status of the channel.
    * When the channel is open or closing you can potentially
    * receive commands on the channel.
@@ -54,14 +64,20 @@ export class Channel {
    */
   constructor({
     id,
+    name,
+    service,
     send,
     onUnrecoverableError,
   }: {
     id: number;
+    name?: string;
+    service?: string;
     send: (cmd: api.Command) => void;
     onUnrecoverableError: (e: Error) => void;
   }) {
     this.id = id;
+    this.name = name;
+    this.service = service;
     this.sendToContainer = send;
     this.onUnrecoverableError = onUnrecoverableError;
     this.status = 'open';

--- a/src/types.ts
+++ b/src/types.ts
@@ -77,6 +77,11 @@ export type DebugLog =
       type: 'log';
       log: {
         direction: 'in' | 'out';
+        channel: {
+          id: number;
+          name?: string;
+          service?: string;
+        };
         cmd: api.Command;
       };
     };


### PR DESCRIPTION
Why
===

Previously one had to pay attention and manually correlate what channels
correspond to what services when inspecting the crosis logs. That's a
bit too hard for humans, and the machines can do that for us.

What changed
============

This change adds the channel service (if available) and name (if
available) for all crosis logs.

Test plan
=========

![image](https://user-images.githubusercontent.com/168028/167331332-a6abba91-a169-4103-bc38-7e1c15c856ed.png)
