### PR TITLE
Remove retryTimeoutId after closing

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -950,14 +950,14 @@ export class Client<Ctx extends unknown = null> {
       });
     }
 
-    const isPolling =
-        websocketFailureCount >= 3 && this.connectOptions.pollingHost;
+    const isPolling = websocketFailureCount >= 3 && this.connectOptions.pollingHost;
     const WebSocketClass = isPolling
       ? EIOCompat
       : getWebSocketClass(this.connectOptions.WebSocketClass);
-    const connStr = getConnectionStr(this.connectionMetadata,
-                                     isPolling ? this.connectOptions.pollingHost
-                                               : undefined);
+    const connStr = getConnectionStr(
+      this.connectionMetadata,
+      isPolling ? this.connectOptions.pollingHost : undefined,
+    );
     const ws = new WebSocketClass(connStr);
 
     ws.binaryType = 'arraybuffer';
@@ -1354,6 +1354,7 @@ export class Client<Ctx extends unknown = null> {
     if (this.retryTimeoutId) {
       // Client was closed while reconnecting
       clearTimeout(this.retryTimeoutId);
+      this.retryTimeoutId = null;
     }
 
     const willClientReconnect = closeResult.closeReason === ClientCloseReason.Disconnected;


### PR DESCRIPTION
Why
===
We see `unexpected existing retryTimeoutId` in our error logs. 

What changed
============
I cleared `retryTimeoutId` inside `handleClose` when we clear the timeout.

Test plan
=========
I'm gonna add a test in a follow up PR that handles this case and more reconnect/retry cases, but here's how to reproduce this current issue:
1. Open a client
2. Get it in a state where it's reconnecting
3. Just before it reconnects call `close` on the client
4. Re-open the client
5. Get it in a state where it's reconnecting
6. ERROR 