### PR TITLE
Fm rework retry

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -87,7 +87,7 @@ export interface ConnectOptions<Ctx> {
   context: Ctx;
   reuseConnectionMetadata: boolean;
   pollingHost?: string;
-  retryCallback?: RetryCb;
+  retryCallback: RetryCb;
 }
 
 export interface UrlOptions {

--- a/src/util/EIOCompat.ts
+++ b/src/util/EIOCompat.ts
@@ -206,6 +206,17 @@ export class EIOCompat implements WebSocket {
         const event = createEvent('error');
         this.onerror.call(this, event);
       }
+
+      // According to the specification, close is always called after error
+      // https://websockets.spec.whatwg.org/#closeWebSocket
+      if (this.onclose != null) {
+        const event = createCloseEvent({
+          code: 1001,
+          wasClean: false,
+        });
+
+        this.onclose.call(this, event);
+      }
     });
   }
 

--- a/src/util/helpers.ts
+++ b/src/util/helpers.ts
@@ -1,17 +1,36 @@
 import * as urllib from 'url';
-import type { ConnectOptions, GovalMetadata } from '../types';
+import { ConnectionError, ConnectOptions, GovalMetadata, RetryCb } from '../types';
 
 const BACKOFF_FACTOR = 1.7;
 const MAX_BACKOFF = 15000;
 
-/**
- * Calculates the backoff for n retry
- */
-export function getNextRetryDelay(retryNumber: number): number {
+function getNextRetryDelay(retryNumber: number): number {
   const randomMs = Math.floor(Math.random() * 500);
   const backoff = BACKOFF_FACTOR ** retryNumber * 1000;
 
   return Math.min(backoff, MAX_BACKOFF) + randomMs;
+}
+
+export function createDefaultRetryCallback(): RetryCb {
+  let websocketFailureCount = 0;
+
+  return async function retryCallback({
+    count,
+    retryReason,
+  }: {
+    count: number;
+    retryReason: ConnectionError;
+  }) {
+    if (retryReason === ConnectionError.SocketClosure) {
+      websocketFailureCount += 1;
+    }
+
+    return {
+      shouldAbort: false,
+      backOffMs: getNextRetryDelay(count),
+      shouldPoll: websocketFailureCount > 3,
+    };
+  };
 }
 
 function isWebSocket(w: unknown): w is WebSocket {

--- a/src/util/helpers.ts
+++ b/src/util/helpers.ts
@@ -11,7 +11,7 @@ function getNextRetryDelay(retryNumber: number): number {
   return Math.min(backoff, MAX_BACKOFF) + randomMs;
 }
 
-export function createDefaultRetryCallback(): RetryCb {
+export function createDefaultRetryCallback(hasPolling: boolean): RetryCb {
   let websocketFailureCount = 0;
 
   return async function retryCallback({
@@ -28,7 +28,7 @@ export function createDefaultRetryCallback(): RetryCb {
     return {
       shouldAbort: false,
       backOffMs: getNextRetryDelay(count),
-      shouldPoll: websocketFailureCount > 3,
+      shouldPoll: websocketFailureCount > 3 && hasPolling,
     };
   };
 }


### PR DESCRIPTION
WIP just putting it up for visibility. The gist of it is to delegate some of the retry logic to the user

Why
===
We need to delegate more of retry logic to clients and applications. For example, change retry rate based on external factors, or handle retries completely in UI.

What changed
============
- Delegate retries to caller
- Emit websocket error codes and other reconnect reasons
- Allow for aborting


Test plan
=========
WIP