### PR TITLE
Fix timeouts lingering after closing

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1238,7 +1238,7 @@ test('does not fallback to polling if host is unset', (done) => {
   );
 }, 40000);
 
-test.only('cancels connection timeout when closing', (done) => {
+test('cancels connection timeout when closing', (done) => {
   const client = getClient(done);
 
   const WebsocketThatNeverConnects = getWebsocketClassThatNeverConnects();

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -64,6 +64,13 @@ function wrapWithDone<Args extends Array<any>, Ret>(
 function getWebsocketClassThatNeverConnects() {
   class _WebsocketThatNeverConnects {
     static OPEN = 1;
+    onclose?: (closeEvent: CloseEvent) => void;
+
+    send = () => {};
+
+    close = (code = 1000, reason?: string) => {
+      setTimeout(() => this.onclose?.(createCloseEvent({ code, reason })));
+    };
   }
 
   const WebsocketThatNeverConnects = _WebsocketThatNeverConnects as typeof WebSocket;

--- a/src/util/EIOCompat.ts
+++ b/src/util/EIOCompat.ts
@@ -42,7 +42,10 @@ function createMessageEvent(data: ArrayBuffer): MessageEvent {
   } as MessageEvent;
 }
 
-function createCloseEvent(info: CloseEventInit): CloseEvent {
+/**
+ * @hidden
+ */
+export function createCloseEvent(info: CloseEventInit): CloseEvent {
   if (typeof window !== 'undefined') {
     return new CloseEvent('close', info);
   }


### PR DESCRIPTION
Why
===
If we have a pending connection with a timeout option and we close in the middle of it connecting, the timeout lingers and leads to undefined behavior, from my testing it seems like it bottoms out here https://github.com/replit/crosis/blob/711c2bd7079b426857d4a41a0a6959e2ebac89f0/src/client.ts#L1233-L1238 which seems innocent, but the problem is that it calls https://github.com/replit/crosis/blob/711c2bd7079b426857d4a41a0a6959e2ebac89f0/src/client.ts#L1198-L1200 before getting there, leading to a spooky undefined state.

<sup><sup><sup><sup><sup><sup><sup>This whole library feels like it should much much simpler! Coroutines? Reactivity? State machine?</sup></sup></sup></sup></sup></sup></sup>

What changed
============
- Added check inside `onFailed` to make sure we don't have multiple connections tries going on at once. It checks referential equality for things unique to a connect try.
- Introduce `connectTimeoutId` property on the class, use it during closing to clear up the timeout (this is the fix)
- Moved abort controller aborting to a common cleanup place
- Added a test
- Made `getClient` in tests require `done` so that it passes it as an unrecoverable error handler and fail the test
- Made `WebsocketThatNeverConnects` in testing follow `close` semantics of real websockets

Test plan
=========
Other than adding the test, the breadcrumbs prove that we don't have any lingering timeouts.