### PR TITLE
Rename addDebugFunc to onDebugLog

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -201,7 +201,7 @@ test('client retries and caches tokens', (done) => {
   const fetchConnectionMetadata = jest.fn();
 
   let reconnectCount = 0;
-  client.addDebugFunc((log) => {
+  client.onDebugLog((log) => {
     if (log.type !== 'breadcrumb' || log.message !== 'retrying') {
       return;
     }
@@ -250,7 +250,7 @@ test('client retries but does not cache tokens', (done) => {
   const fetchConnectionMetadata = jest.fn();
 
   let reconnectCount = 0;
-  client.addDebugFunc((log) => {
+  client.onDebugLog((log) => {
     if (log.type !== 'breadcrumb' || log.message !== 'retrying') {
       return;
     }
@@ -1074,7 +1074,7 @@ test('client is closed while reconnecting', (done) => {
   const onOpen = jest.fn();
 
   const client = getClient(done);
-  client.addDebugFunc((log) => {
+  client.onDebugLog((log) => {
     if (log.type === 'breadcrumb' && log.message === 'reconnecting') {
       setTimeout(() => {
         client.close();
@@ -1114,7 +1114,7 @@ test('client is closed while reconnecting', (done) => {
 
 test('closing before ever connecting', (done) => {
   const client = getClient(done);
-  client.addDebugFunc((log) => {
+  client.onDebugLog((log) => {
     if (log.type === 'breadcrumb' && log.message === 'connecting') {
       setTimeout(() => {
         client.close();
@@ -1163,7 +1163,7 @@ test('fallback to polling', (done) => {
   const WebsocketThatNeverConnects = getWebsocketClassThatNeverConnects();
 
   let didLogFallback = false;
-  client.addDebugFunc((log) => {
+  client.onDebugLog((log) => {
     if (log.type === 'breadcrumb' && log.message === 'polling fallback') {
       didLogFallback = true;
     }
@@ -1201,7 +1201,7 @@ test('does not fallback to polling if host is unset', (done) => {
   const WebsocketThatNeverConnects = getWebsocketClassThatNeverConnects();
 
   let didLogFallback = false;
-  client.addDebugFunc((log) => {
+  client.onDebugLog((log) => {
     if (
       log.type === 'breadcrumb' &&
       log.message === 'connecting' &&
@@ -1245,7 +1245,7 @@ test('cancels connection timeout when closing', (done) => {
 
   const timeout = 2000;
 
-  client.addDebugFunc((log) => {
+  client.onDebugLog((log) => {
     if (log.type === 'breadcrumb' && log.message === 'connecting') {
       setTimeout(() => {
         client.close();

--- a/src/client.ts
+++ b/src/client.ts
@@ -125,14 +125,6 @@ export class Client<Ctx = null> {
   };
 
   /**
-   * Called for breadcrumbs and other debug reasons. Use addDebugFunc
-   * instead
-   *
-   * @hidden
-   */
-  private legacyDebugFunc: undefined | ((log: DebugLog) => void);
-
-  /**
    * Listeners to be called for breadcrumbs and other debug reasons
    *
    * @hidden
@@ -749,26 +741,14 @@ export class Client<Ctx = null> {
    * @hidden
    */
   private debug = (log: DebugLog): void => {
-    if (this.legacyDebugFunc) {
-      this.legacyDebugFunc(log);
-    }
     this.debugFuncs.forEach((func) => func(log));
-  };
-
-  /**
-   * Sets a logging/debugging function
-   *
-   * @deprecated use addDebugFunc instead
-   */
-  public setDebugFunc = (debugFunc: (log: DebugLog) => void): void => {
-    this.legacyDebugFunc = debugFunc;
   };
 
   /**
    * Adds a logging/debugging function. Returns a function that will remove
    * the callback
    */
-  public addDebugFunc = (debugFunc: (log: DebugLog) => void): (() => void) => {
+  public onDebugLog = (debugFunc: (log: DebugLog) => void): (() => void) => {
     this.debugFuncs.push(debugFunc);
 
     return () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -65,7 +65,7 @@ export interface OpenOptions<Ctx> extends Partial<ConnectOptions<Ctx>> {
 }
 
 /**
- * See [[Client.setDebugFunc]]
+ * See [[Client.onDebugLog]]
  */
 export type DebugLog =
   | {


### PR DESCRIPTION
Why
===

Matches our existing event handler naming

What changed
============
- Rename `addDebugFunc` to `onDebugLog`
- Removed deprecated `setDebugFunc`

Test plan
=========
We have tests in place that use this, they should pass