### PR TITLE
Add a way to listen to boot status messages

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -201,7 +201,7 @@ test('client retries and caches tokens', (done) => {
   const fetchConnectionMetadata = jest.fn();
 
   let reconnectCount = 0;
-  client.addDebugFunc((log) => {
+  client.onDebugLog((log) => {
     if (log.type !== 'breadcrumb' || log.message !== 'retrying') {
       return;
     }
@@ -250,7 +250,7 @@ test('client retries but does not cache tokens', (done) => {
   const fetchConnectionMetadata = jest.fn();
 
   let reconnectCount = 0;
-  client.addDebugFunc((log) => {
+  client.onDebugLog((log) => {
     if (log.type !== 'breadcrumb' || log.message !== 'retrying') {
       return;
     }
@@ -1074,7 +1074,7 @@ test('client is closed while reconnecting', (done) => {
   const onOpen = jest.fn();
 
   const client = getClient(done);
-  client.addDebugFunc((log) => {
+  client.onDebugLog((log) => {
     if (log.type === 'breadcrumb' && log.message === 'reconnecting') {
       setTimeout(() => {
         client.close();
@@ -1114,7 +1114,7 @@ test('client is closed while reconnecting', (done) => {
 
 test('closing before ever connecting', (done) => {
   const client = getClient(done);
-  client.addDebugFunc((log) => {
+  client.onDebugLog((log) => {
     if (log.type === 'breadcrumb' && log.message === 'connecting') {
       setTimeout(() => {
         client.close();
@@ -1163,7 +1163,7 @@ test('fallback to polling', (done) => {
   const WebsocketThatNeverConnects = getWebsocketClassThatNeverConnects();
 
   let didLogFallback = false;
-  client.addDebugFunc((log) => {
+  client.onDebugLog((log) => {
     if (log.type === 'breadcrumb' && log.message === 'polling fallback') {
       didLogFallback = true;
     }
@@ -1201,7 +1201,7 @@ test('does not fallback to polling if host is unset', (done) => {
   const WebsocketThatNeverConnects = getWebsocketClassThatNeverConnects();
 
   let didLogFallback = false;
-  client.addDebugFunc((log) => {
+  client.onDebugLog((log) => {
     if (
       log.type === 'breadcrumb' &&
       log.message === 'connecting' &&
@@ -1245,7 +1245,7 @@ test('cancels connection timeout when closing', (done) => {
 
   const timeout = 2000;
 
-  client.addDebugFunc((log) => {
+  client.onDebugLog((log) => {
     if (log.type === 'breadcrumb' && log.message === 'connecting') {
       setTimeout(() => {
         client.close();

--- a/src/client.ts
+++ b/src/client.ts
@@ -125,14 +125,6 @@ export class Client<Ctx = null> {
   };
 
   /**
-   * Called for breadcrumbs and other debug reasons. Use addDebugFunc
-   * instead
-   *
-   * @hidden
-   */
-  private legacyDebugFunc: undefined | ((log: DebugLog) => void);
-
-  /**
    * Listeners to be called for breadcrumbs and other debug reasons
    *
    * @hidden
@@ -749,26 +741,14 @@ export class Client<Ctx = null> {
    * @hidden
    */
   private debug = (log: DebugLog): void => {
-    if (this.legacyDebugFunc) {
-      this.legacyDebugFunc(log);
-    }
     this.debugFuncs.forEach((func) => func(log));
-  };
-
-  /**
-   * Sets a logging/debugging function
-   *
-   * @deprecated use addDebugFunc instead
-   */
-  public setDebugFunc = (debugFunc: (log: DebugLog) => void): void => {
-    this.legacyDebugFunc = debugFunc;
   };
 
   /**
    * Adds a logging/debugging function. Returns a function that will remove
    * the callback
    */
-  public addDebugFunc = (debugFunc: (log: DebugLog) => void): (() => void) => {
+  public onDebugLog = (debugFunc: (log: DebugLog) => void): (() => void) => {
     this.debugFuncs.push(debugFunc);
 
     return () => {

--- a/src/client.ts
+++ b/src/client.ts
@@ -132,6 +132,12 @@ export class Client<Ctx = null> {
   private debugFuncs: Array<(log: DebugLog) => void>;
 
   /**
+   * Listeners to be called for BootStatus messages
+   *
+   */
+  private bootStatusFuncs: Array<(cmd: api.BootStatus) => void>;
+
+  /**
    * A function supplied to us by the user of the client. Will be called
    * any time we have an unrecoverable error, usually an invariance
    *
@@ -195,6 +201,7 @@ export class Client<Ctx = null> {
     this.chan0CleanupCb = null;
     this.connectionState = ConnectionState.DISCONNECTED;
     this.debugFuncs = [];
+    this.bootStatusFuncs = [];
     this.userUnrecoverableErrorHandler = null;
     this.channelRequests = [];
     this.retryTimeoutId = null;
@@ -760,6 +767,21 @@ export class Client<Ctx = null> {
   };
 
   /**
+   * Adds a listener for bootstatus messages coming in from the backend
+   * before we acquire and connect to the container.
+   */
+  public onBootStatus = (bootStatusFunc: (command: api.BootStatus) => void): (() => void) => {
+    this.bootStatusFuncs.push(bootStatusFunc);
+
+    return () => {
+      const idx = this.bootStatusFuncs.indexOf(bootStatusFunc);
+      if (idx > -1) {
+        this.bootStatusFuncs.splice(idx, 1);
+      }
+    };
+  };
+
+  /**
    * Set a function to handle unrecoverable error
    *
    * Unrecoverable errors are internal errors or invariance errors
@@ -1109,6 +1131,13 @@ export class Client<Ctx = null> {
         this.onUnrecoverableError(
           new Error("Can't connect to unfirewalled repl from firewall mode"),
         );
+
+        return;
+      }
+
+      const bootStatus = cmd.bootStatus;
+      if (bootStatus) {
+        this.bootStatusFuncs.forEach((fn) => fn(bootStatus));
 
         return;
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -65,7 +65,7 @@ export interface OpenOptions<Ctx> extends Partial<ConnectOptions<Ctx>> {
 }
 
 /**
- * See [[Client.setDebugFunc]]
+ * See [[Client.onDebugLog]]
  */
 export type DebugLog =
   | {


### PR DESCRIPTION
Why
===

There's no way for the user to read control channel messages before we connect and user gets an instance of channel 0. We'll add an explicit listener for boot status messages.

https://app.asana.com/0/1202342654232057/1202342654232071

What changed
============
- Add `onBootStatus` event listener
- call when we get a bootstatus message during connection

Test plan
=========
Added a test