### PR TITLE
Bump crosis version to 9.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replit/crosis",
-  "version": "9.0.0",
+  "version": "9.0.1",
   "description": "Goval connection and channel manager",
   "files": [
     "/dist"


### PR DESCRIPTION
Why
===

I don't know if this change would be considered breaking or not, but the main change is that instead of emitting an unrecoverable error, firewallDenied will call a dedicated callback function that can be set by the client.

What changed
============

9.0.0 -> 9.0.1

Test plan
=========

Tests pass