### PR TITLE
type debug log breadcrumbs

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -129,7 +129,7 @@ export class Client<Ctx = null> {
    *
    * @hidden
    */
-  private debugFuncs: Array<(log: DebugLog) => void>;
+  private debugFuncs: Array<(log: DebugLog<Ctx>) => void>;
 
   /**
    * Listeners to be called for BootStatus messages
@@ -748,7 +748,7 @@ export class Client<Ctx = null> {
    *
    * @hidden
    */
-  private debug = (log: DebugLog): void => {
+  private debug = (log: DebugLog<Ctx>): void => {
     this.debugFuncs.forEach((func) => func(log));
   };
 
@@ -756,7 +756,7 @@ export class Client<Ctx = null> {
    * Adds a logging/debugging function. Returns a function that will remove
    * the callback
    */
-  public onDebugLog = (debugFunc: (log: DebugLog) => void): (() => void) => {
+  public onDebugLog = (debugFunc: (log: DebugLog<Ctx>) => void): (() => void) => {
     this.debugFuncs.push(debugFunc);
 
     return () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,15 +64,122 @@ export interface OpenOptions<Ctx> extends Partial<ConnectOptions<Ctx>> {
   context: Ctx;
 }
 
+type GenericBreadcrumb = {
+  type: 'breadcrumb';
+  message:
+    | 'constructor'
+    | 'openChanres'
+    | 'connected!'
+    | 'user close'
+    | 'cancel timeout'
+    | 'reset timeout'
+    | 'connect timeout'
+    | 'polling fallback'
+    | 'reconnecting'
+    | 'destroy';
+};
+
+type DebugLogBreadcrumb<Ctx> =
+  | GenericBreadcrumb
+  | {
+      type: 'breadcrumb';
+      message: 'open';
+      data: {
+        polling: false;
+      };
+    }
+  | {
+      type: 'breadcrumb';
+      message: 'connecting';
+      data: {
+        connectionState: ConnectionState;
+        connectTries: number;
+        websocketFailureCount: number;
+        readyState: WebSocket['readyState'] | undefined;
+        chan0CbExists: boolean;
+      };
+    }
+  | {
+      type: 'breadcrumb';
+      message: 'requestOpenChannel';
+      data?: {
+        name: ChannelOptions<Ctx>['name'];
+        service: ChannelOptions<Ctx>['service'];
+        action: api.OpenChannel.Action;
+      };
+    }
+  | {
+      type: 'breadcrumb';
+      message: 'requestChannelClose';
+      data: {
+        id: number;
+        name: ChannelOptions<Ctx>['name'];
+        service: ChannelOptions<Ctx>['service'];
+      };
+    }
+  | {
+      type: 'breadcrumb';
+      message: 'requestChannelClose:chan0Closed';
+      data: {
+        id: number;
+        name: ChannelOptions<Ctx>['name'];
+        service: ChannelOptions<Ctx>['service'];
+      };
+    }
+  | {
+      type: 'breadcrumb';
+      message: 'requestChannelClose:closeChanRes';
+      data: {
+        id: number;
+        name: ChannelOptions<Ctx>['name'];
+        service: string | ServiceThunk<Ctx>;
+        closeStatus: api.CloseChannelRes.Status;
+      };
+    }
+  | {
+      type: 'breadcrumb';
+      message: 'retrying';
+      data: {
+        connectionState: ConnectionState;
+        connectTries: number;
+        websocketFailureCount: number;
+        error: Error;
+        wsReadyState?: WebSocket['readyState'];
+      };
+    }
+  | {
+      type: 'breadcrumb';
+      message: 'containerState';
+      data: api.ContainerState.State;
+    }
+  | {
+      message: 'wsclose';
+      data?: {
+        event: CloseEvent | Event;
+      };
+    }
+  | {
+      type: 'breadcrumb';
+      message: 'cleanupSocket';
+      data: {
+        hasWs: boolean;
+        readyState: WebSocket['readyState'] | null;
+        connectionState: ConnectionState;
+      };
+    }
+  | {
+      type: 'breadcrumb';
+      message: 'unrecoverable error';
+      data: {
+        message: string;
+      };
+    };
+
 /**
  * See [[Client.onDebugLog]]
  */
-export type DebugLog =
-  | {
-      type: 'breadcrumb';
-      message: string;
-      data?: unknown;
-    }
+export type DebugLog<Ctx> =
+  | DebugLogBreadcrumb<Ctx>
   | {
       type: 'log';
       log: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -103,7 +103,7 @@ export type DebugLogBreadcrumb<Ctx> =
       data?: {
         name: ChannelOptions<Ctx>['name'];
         service: ChannelOptions<Ctx>['service'];
-        action: api.OpenChannel.Action;
+        action: ChannelOptions<Ctx>['action'];
       };
     }
   | {
@@ -130,7 +130,7 @@ export type DebugLogBreadcrumb<Ctx> =
       data: {
         id: number;
         name: ChannelOptions<Ctx>['name'];
-        service: string | ServiceThunk<Ctx>;
+        service: ChannelOptions<Ctx>['service'];
         closeStatus: api.CloseChannelRes.Status;
       };
     }
@@ -185,8 +185,8 @@ export type DebugLog<Ctx> =
         direction: 'in' | 'out';
         channel: {
           id: number;
-          name?: string;
-          service?: string;
+          name?: ChannelOptions<Ctx>['name'];
+          service?: ChannelOptions<Ctx>['service'];
         };
         cmd: api.Command;
       };

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,23 +64,21 @@ export interface OpenOptions<Ctx> extends Partial<ConnectOptions<Ctx>> {
   context: Ctx;
 }
 
-type GenericBreadcrumb = {
-  type: 'breadcrumb';
-  message:
-    | 'constructor'
-    | 'openChanres'
-    | 'connected!'
-    | 'user close'
-    | 'cancel timeout'
-    | 'reset timeout'
-    | 'connect timeout'
-    | 'polling fallback'
-    | 'reconnecting'
-    | 'destroy';
-};
-
-type DebugLogBreadcrumb<Ctx> =
-  | GenericBreadcrumb
+export type DebugLogBreadcrumb<Ctx> =
+  | {
+      type: 'breadcrumb';
+      message:
+        | 'constructor'
+        | 'openChanres'
+        | 'connected!'
+        | 'user close'
+        | 'cancel timeout'
+        | 'reset timeout'
+        | 'connect timeout'
+        | 'polling fallback'
+        | 'reconnecting'
+        | 'destroy';
+    }
   | {
       type: 'breadcrumb';
       message: 'open';
@@ -153,6 +151,7 @@ type DebugLogBreadcrumb<Ctx> =
       data: api.ContainerState.State;
     }
   | {
+      type: 'breadcrumb';
       message: 'wsclose';
       data?: {
         event: CloseEvent | Event;


### PR DESCRIPTION
Why
===

create types for breadcrumbs for the consumer of the library. `unknown` is not good

One use case is consumer end could filter out only the debug message they are interested in.

What changed
============

type all the things in breadcrumb


