### PR TITLE
classify retriable errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "eslint-plugin-prettier": "4.0.0",
     "express": "^4.18.1",
     "jest": "^28.1.0",
-    "jest-websocket-mock": "^2.3.0",
+    "jest-websocket-mock": "^2.4.0",
     "mock-socket": "^9.1.5",
     "parcel": "1.12.3",
     "prettier": "^2.6.2",

--- a/src/__tests__/retry.test.ts
+++ b/src/__tests__/retry.test.ts
@@ -1,0 +1,132 @@
+/* eslint-env jest */
+
+import { Client } from '..';
+import WS from 'jest-websocket-mock';
+import { WebSocket } from 'mock-socket';
+import { CloseCode, FetchConnectionMetadataError } from '../types';
+import { wrapWithDone } from '../__testutils__/done';
+
+// eslint-disable-next-line
+const genConnectionMetadata = require('../../debug/genConnectionMetadata');
+
+// eslint-disable-next-line
+jest.setTimeout(1000);
+
+const testingClients: Array<Client<{ username: string }>> = [];
+
+const genConnectionMetadataWithGurl = (gurl: string) => {
+  const connectionMetadata = genConnectionMetadata();
+  connectionMetadata.gurl = gurl;
+  connectionMetadata.token = ''; // need this so the mock server connects
+  return connectionMetadata;
+};
+
+const port = 9751;
+
+afterAll(() => {
+  testingClients.forEach((c) => {
+    c.destroy();
+  });
+});
+
+describe('retry handling', () => {
+  test('should not retry for user error', (done) => {
+    const ctx = { username: 'zyzz' };
+    const client = new Client<{ username: string }>();
+    client.setUnrecoverableErrorHandler((e) => {
+      console.log('got unrecoverable error: ', e);
+    });
+    testingClients.push(client);
+    const addr1 = 'ws://localhost:' + port;
+    const server = new WS(addr1 + '/wsv2/');
+
+    server.error({ code: CloseCode.USER_ERROR, reason: 'user error', wasClean: true });
+
+    let tryCount = 0;
+    const connectionMetadata = genConnectionMetadataWithGurl(addr1);
+    client.open(
+      {
+        fetchConnectionMetadata: () => {
+          tryCount++;
+
+          if (tryCount === 1) {
+            return Promise.resolve({
+              error: FetchConnectionMetadataError.Retriable,
+            });
+          }
+
+          return Promise.resolve({
+            ...connectionMetadata,
+            error: null,
+          });
+        },
+        WebSocketClass: WebSocket,
+        context: ctx,
+      },
+      wrapWithDone(done, ({ error }) => {
+        expect(tryCount).toBe(1);
+        expect(error?.message).toBe('Failed to open');
+
+        client.close();
+
+        return () => {
+          server.close();
+
+          done();
+        };
+      }),
+    );
+  });
+
+  test('should retry for try another machine', (done) => {
+    const ctx = { username: 'zyzz' };
+    const client = new Client<{ username: string }>();
+    client.setUnrecoverableErrorHandler((e) => {
+      console.log('got unrecoverable error: ', e);
+    });
+    testingClients.push(client);
+    const addr1 = 'ws://localhost:' + port;
+    const server = new WS(addr1 + '/wsv2/');
+
+    server.error({
+      code: CloseCode.TRY_ANOTHER_MACHINE,
+      reason: 'try another machine',
+      wasClean: true,
+    });
+
+    let tryCount = 0;
+    const connectionMetadata = genConnectionMetadataWithGurl(addr1);
+    client.open(
+      {
+        fetchConnectionMetadata: () => {
+          tryCount++;
+
+          if (tryCount === 1) {
+            return Promise.resolve({
+              error: FetchConnectionMetadataError.Retriable,
+            });
+          }
+
+          return Promise.resolve({
+            ...connectionMetadata,
+            error: null,
+          });
+        },
+        WebSocketClass: WebSocket,
+        context: ctx,
+      },
+      wrapWithDone(done, ({ error }) => {
+        expect(tryCount).toBe(2);
+        expect(error?.message).toBe('Failed to open');
+
+        client.close();
+
+        return () => {
+          server.close();
+
+          done();
+        };
+      }),
+    );
+  });
+});

--- a/src/client.ts
+++ b/src/client.ts
@@ -1295,6 +1295,7 @@ export class Client<Ctx = null> {
 
       if (!retriable) {
         this.onUnrecoverableError(error);
+        return;
       }
 
       this.retryConnect({

--- a/src/types.ts
+++ b/src/types.ts
@@ -267,3 +267,11 @@ export type OpenChannelCb<Ctx> = (
 export interface RequestResult extends api.Command {
   channelClosed?: ChannelCloseReason;
 }
+
+export const CloseCode = {
+  INVALID_UPSTREAM_RESPONSE: 1014,
+  POLICY_VIOLATION: 1008,
+  FIREWALL_DENIED: 4000,
+  TRY_ANOTHER_MACHINE: 4001,
+  USER_ERROR: 4002,
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1245,6 +1245,13 @@
   dependencies:
     "@sinclair/typebox" "^0.23.3"
 
+"@jest/schemas@^28.1.3":
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/@jest/schemas/-/schemas-28.1.3.tgz#ad8b86a66f11f33619e3d7e1dcddd7f2d40ff905"
+  integrity sha512-/l/VWsdt/aBXgjshLWOFyFt3IVdYypu5y2Wn2rOO1un6nkqIn8SLXzgIMYXFyYsRWDyF5EthmKJMIdJvk08grg==
+  dependencies:
+    "@sinclair/typebox" "^0.24.1"
+
 "@jest/source-map@^28.0.2":
   version "28.0.2"
   resolved "https://registry.yarnpkg.com/@jest/source-map/-/source-map-28.0.2.tgz#914546f4410b67b1d42c262a1da7e0406b52dc90"
@@ -1499,6 +1506,11 @@
   version "0.23.5"
   resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.23.5.tgz#93f7b9f4e3285a7a9ade7557d9a8d36809cbc47d"
   integrity sha512-AFBVi/iT4g20DHoujvMH1aEDn8fGJh4xsRGCP6d8RpLPMqsNPvW01Jcn0QysXTsg++/xj25NmJsGyH9xug/wKg==
+
+"@sinclair/typebox@^0.24.1":
+  version "0.24.27"
+  resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.24.27.tgz#d55643516a1546174e10da681a8aaa81e757452d"
+  integrity sha512-K7C7IlQ3zLePEZleUN21ceBA2aLcMnLHTLph8QWk1JK37L90obdpY+QGY8bXMKxf1ht1Z0MNewvXxWv0oGDYFg==
 
 "@sinonjs/commons@^1.7.0":
   version "1.8.0"
@@ -3164,6 +3176,11 @@ diff-sequences@^28.0.2:
   version "28.0.2"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-28.0.2.tgz#40f8d4ffa081acbd8902ba35c798458d0ff1af41"
   integrity sha512-YtEoNynLDFCRznv/XDalsKGSZDoj0U5kLnXvY0JSq3nBboRrZXjD81+eSiwi+nzcZDwedMmcowcxNwwgFW23mQ==
+
+diff-sequences@^28.1.1:
+  version "28.1.1"
+  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-28.1.1.tgz#9989dc731266dc2903457a70e996f3a041913ac6"
+  integrity sha512-FU0iFaH/E23a+a718l8Qa/19bF9p06kgE0KipMOMadwa3SjnaElKzPaUC0vnibs6/B/9ni97s61mcejk8W1fQw==
 
 diffie-hellman@^5.0.0:
   version "5.0.3"
@@ -4958,7 +4975,7 @@ jest-config@^28.1.0:
     slash "^3.0.0"
     strip-json-comments "^3.1.1"
 
-jest-diff@^27.0.2, jest-diff@^27.5.1:
+jest-diff@^27.5.1:
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-27.5.1.tgz#a07f5011ac9e6643cf8a95a462b7b1ecf6680def"
   integrity sha512-m0NvkX55LDt9T4mctTEgnZk3fmEg3NRYutvMPWM/0iPnkFj2wIeF45O1718cMSOFO1vINkqmxqD8vE37uTEbqw==
@@ -4967,6 +4984,16 @@ jest-diff@^27.0.2, jest-diff@^27.5.1:
     diff-sequences "^27.5.1"
     jest-get-type "^27.5.1"
     pretty-format "^27.5.1"
+
+jest-diff@^28.0.2:
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-28.1.3.tgz#948a192d86f4e7a64c5264ad4da4877133d8792f"
+  integrity sha512-8RqP1B/OXzjjTWkqMX67iqgwBVJRgCyKD3L9nq+6ZqJMdvjE8RgHktqZ6jNrkdMT+dJuYNI3rhQpxaz7drJHfw==
+  dependencies:
+    chalk "^4.0.0"
+    diff-sequences "^28.1.1"
+    jest-get-type "^28.0.2"
+    pretty-format "^28.1.3"
 
 jest-diff@^28.1.0:
   version "28.1.0"
@@ -5243,12 +5270,12 @@ jest-watcher@^28.1.0:
     jest-util "^28.1.0"
     string-length "^4.0.1"
 
-jest-websocket-mock@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/jest-websocket-mock/-/jest-websocket-mock-2.3.0.tgz#317e7d7f8ba54ba632a7300777b02b7ebb606845"
-  integrity sha512-kXhRRApRdT4hLG/4rhsfcR0Ke0OzqIsDj0P5t0dl5aiAftShSgoRqp/0pyjS5bh+b9GrIzmfkrV2cn9LxxvSvA==
+jest-websocket-mock@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/jest-websocket-mock/-/jest-websocket-mock-2.4.0.tgz#95ab1f89f809e57d2714427736ab7b1094fb1c3c"
+  integrity sha512-AOwyuRw6fgROXHxMOiTDl1/T4dh3fV4jDquha5N0csS/PNp742HeTZWPAuKppVRSQ8s3fUGgJHoyZT9JDO0hMA==
   dependencies:
-    jest-diff "^27.0.2"
+    jest-diff "^28.0.2"
     mock-socket "^9.1.0"
 
 jest-worker@^28.1.0:
@@ -6771,6 +6798,16 @@ pretty-format@^28.1.0:
   integrity sha512-79Z4wWOYCdvQkEoEuSlBhHJqWeZ8D8YRPiPctJFCtvuaClGpiwiQYSCUOE6IEKUbbFukKOTFIUAXE8N4EQTo1Q==
   dependencies:
     "@jest/schemas" "^28.0.2"
+    ansi-regex "^5.0.1"
+    ansi-styles "^5.0.0"
+    react-is "^18.0.0"
+
+pretty-format@^28.1.3:
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-28.1.3.tgz#c9fba8cedf99ce50963a11b27d982a9ae90970d5"
+  integrity sha512-8gFb/To0OmxHR9+ZTb14Df2vNxdGCX8g1xWGUTqUw5TiZvcQf5sHKObd5UcPyLLyowNwDAMTF3XWOG1B6mxl1Q==
+  dependencies:
+    "@jest/schemas" "^28.1.3"
     ansi-regex "^5.0.1"
     ansi-styles "^5.0.0"
     react-is "^18.0.0"


### PR DESCRIPTION
Why
===

Classify retriable and non-retriable errors so the client will not retry on unretriable errors, e.g. user errors.

What changed
============

_Describe what changed to a level of detail that someone with no context with your PR could be able to review it_

Add error code for retriable and non-retriable error and logic to handle them

Test plan
=========

_Describe what you did to test this change to a level of detail that allows your reviewer to test it_

Automation and test the errors are not retriable for an unretriable error. e.g. the client doesn't send get connection metadata call in an expected situation of user error.