### PR TITLE
Make it possible to supply own backoff function

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -44,6 +44,7 @@ export interface ConnectOptions<Ctx> {
   context: Ctx;
   reuseConnectionMetadata: boolean;
   pollingHost?: string;
+  getNextRetryDelayMs: (tryCount: number) => number;
 }
 
 export interface UrlOptions {

--- a/src/util/helpers.ts
+++ b/src/util/helpers.ts
@@ -7,7 +7,7 @@ const MAX_BACKOFF = 15000;
 /**
  * Calculates the backoff for n retry
  */
-export function getNextRetryDelay(retryNumber: number): number {
+export function defaultGetNextRetryDelay(retryNumber: number): number {
   const randomMs = Math.floor(Math.random() * 500);
   const backoff = BACKOFF_FACTOR ** retryNumber * 1000;
 


### PR DESCRIPTION
Why
===
We should be able to easily tweak from the frontend

Stepping stone for #121

We should consider pulling in back this package into our monorepo until we're ready to open our API again.

What changed
============
Added option to supply a backoff function `getNextRetryDelayMs`, fallsback to current one.


Test plan
=========

Testing in the web repo, currently aiming to ship for incident response