### PR TITLE
Make tests run. (Ignore proxy steps in boot stages.)

### DIFF
--- a/debug/genConnectionMetadata.js
+++ b/debug/genConnectionMetadata.js
@@ -41,7 +41,7 @@ function genConnectionMetadata(options) {
       seconds: Math.floor(now / 1000) + 60 * 60,
     },
     cluster: 'global',
-    persistence: api.ReplToken.Persistence.NONE,
+    persistence: api.repl.Persistence.NONE,
     format: api.ReplToken.WireFormat.PROTOBUF,
     repl,
     resourceLimits: {

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1336,6 +1336,13 @@ concurrent('emits boot status messages', (done) => {
   let count = 0;
   client.onBootStatus(
     wrapWithDone(done, (bootStatus) => {
+      if (bootStatus.stage === api.BootStatus.Stage.PROXY) {
+        // we're just going to ignore any proxy steps for the sake of counting
+        // the order of the other steps; they're optional and potentially
+        // stochastic.
+        return;
+      }
+
       count++;
 
       if (count === 1) {


### PR DESCRIPTION
Why
===

Proxying behavior changed since the tests were last run. 