### PR TITLE
(typos)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replit/crosis",
-  "version": "9.2.0",
+  "version": "9.2.1",
   "description": "Goval connection and channel manager",
   "files": [
     "/dist"

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -830,7 +830,7 @@ concurrent(
             expect(channel).toBeTruthy();
 
             if (!channel) {
-              throw new Error('apease typescript');
+              throw new Error('appease typescript');
             }
 
             firstChannel = channel;
@@ -908,7 +908,7 @@ concurrent('opens multiple anonymous channels while client is connected', (done)
         { service: 'exec' },
         wrapWithDone(done, ({ channel }) => {
           if (firstOpened) {
-            doneOnce(new Error('exepected channel to open only once'));
+            doneOnce(new Error('expected channel to open only once'));
 
             return;
           }
@@ -926,7 +926,7 @@ concurrent('opens multiple anonymous channels while client is connected', (done)
         { service: 'exec' },
         wrapWithDone(done, ({ channel }) => {
           if (secondOpened) {
-            doneOnce(new Error('exepected channel to open only once'));
+            doneOnce(new Error('expected channel to open only once'));
 
             return;
           }
@@ -1230,7 +1230,7 @@ concurrent(
           setTimeout(() => {
             done();
             // ample time for the other timeout to clear up
-            // and reak havoc if it was to do that.
+            // and wreak havoc if it was to do that.
           }, timeout + 100);
         });
       }

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -46,7 +46,7 @@ export class Channel {
    * Make shift event emitter listener array. Any time `onCommand`
    * is called we push the callback into this array.
    * When we receive a command from the client through
-   * `handleCommand` we call all the callbakcs in this array
+   * `handleCommand` we call all the callbacks in this array
    *
    * @hidden
    */
@@ -161,7 +161,7 @@ export class Channel {
   /**
    * @hidden should only be called by [[Client]]
    *
-   * Called when the channel recieves a message
+   * Called when the channel receives a message
    */
   public handleCommand = (cmd: api.Command): void => {
     this.onCommandListeners.forEach((l) => l(cmd));

--- a/src/client.ts
+++ b/src/client.ts
@@ -164,7 +164,7 @@ export class Client<Ctx = null> {
 
   /**
    * The connection might require multiple retries to be established.
-   * Anytime we need to retry, we should also add an incremental backoff,
+   * Anytime we need to retry, we should also add an incremental back off,
    * we do that using `setTimeout`. When the client closes before our
    * retry is initiated, we clear this timeout.
    *
@@ -1606,7 +1606,7 @@ export class Client<Ctx = null> {
       const { cleanupCb, closeRequested } = channelRequest;
 
       // Re-set the channel request's state
-      // TODO we should stop relying on mutating the same channelrequest
+      // TODO we should stop relying on mutating the same channelRequest
       (channelRequest as ChannelRequest<Ctx>).channelId = null;
       (channelRequest as ChannelRequest<Ctx>).isOpen = false;
       (channelRequest as ChannelRequest<Ctx>).cleanupCb = null;

--- a/src/client.ts
+++ b/src/client.ts
@@ -558,7 +558,7 @@ export class Client<Ctx = null> {
         send: this.send,
       });
       this.channels[id] = channel;
-      // TODO we should stop relying on mutating the same channelrequest
+      // TODO we should stop relying on mutating the same channelRequest
       (channelRequest as ChannelRequest<Ctx>).channelId = id;
       (channelRequest as ChannelRequest<Ctx>).isOpen = true;
 
@@ -813,7 +813,7 @@ export class Client<Ctx = null> {
   };
 
   /**
-   * Adds a listener for bootstatus messages coming in from the backend
+   * Adds a listener for BootStatus messages coming in from the backend
    * before we acquire and connect to the container.
    */
   public onBootStatus = (bootStatusFunc: (command: api.BootStatus) => void): (() => void) => {
@@ -935,8 +935,8 @@ export class Client<Ctx = null> {
     });
     this.channels[0] = chan0;
 
-    // We'll emit bootstatus throughout the lifetime of the channel
-    // bootstatus messages may come in after container state is ready
+    // We'll emit bootStatus throughout the lifetime of the channel
+    // bootStatus messages may come in after container state is ready
     // and so we don't want to dispose this listener until the current
     // connection is completely disposed, which automatically disposes
     // this channel and attached listeners
@@ -1087,7 +1087,7 @@ export class Client<Ctx = null> {
     /**
      * Failure can happen due to a number of reasons
      * 1- Abrupt socket closure
-     * 2- Timedout connection request
+     * 2- Timed out connection request
      * 3- ContainerState.SLEEP command
      * 4- User calling `close` before we connect
      */
@@ -1209,15 +1209,15 @@ export class Client<Ctx = null> {
      * Every time we get a message we reset the connection timeout (if it exists)
      * this is because it signifies that the connection will eventually work.
      *
-     * If we ever get a ContainterState READY we can officially
+     * If we ever get a ContainerState READY we can officially
      * say that the connection is successful and we open chan0 and other `chanReq`s
      *
-     * If we ever get ContainterState SLEEP it means that something went wrong
+     * If we ever get ContainerState SLEEP it means that something went wrong
      * and connection should be dropped
      */
     const unlistenChan0 = chan0.onCommand((cmd: api.Command) => {
       didReceiveAnyCommand = true;
-      // Everytime we get a message on channel0
+      // Every time we get a message on channel0
       // we will reset the timeout
       resetTimeout();
 
@@ -1232,7 +1232,7 @@ export class Client<Ctx = null> {
       }
 
       if (cmd.containerState.state == null) {
-        this.onUnrecoverableError(new Error('Got containterState but state was not defined'));
+        this.onUnrecoverableError(new Error('Got containerState but state was not defined'));
 
         return;
       }
@@ -1314,7 +1314,7 @@ export class Client<Ctx = null> {
       onFailed = null;
 
       // Cleanup related to this connection try. If we retry connecting a new `WebSocket` instance
-      // will be used in additon to new `cancelTimeout` and `unlistenChan0` functions.
+      // will be used in addition to new `cancelTimeout` and `unlistenChan0` functions.
       this.cleanupSocket();
       cancelTimeout();
       unlistenChan0();

--- a/src/client.ts
+++ b/src/client.ts
@@ -164,7 +164,7 @@ export class Client<Ctx = null> {
 
   /**
    * The connection might require multiple retries to be established.
-   * Anytime we need to retry, we should also add an incremental back off,
+   * Anytime we need to retry, we should also add an incremental backoff,
    * we do that using `setTimeout`. When the client closes before our
    * retry is initiated, we clear this timeout.
    *


### PR DESCRIPTION
Why
===

Just want to clean out these typos before doing the 10.x branch.

What changed
============

Literally just typos. Since one was in an `Error` (which doesn't appear to be relied on anywhere), I bumped the patch.

Test plan
=========

:eyes: I inspected web for reliance on the _containter_ typo.
