### PR TITLE
[major->10.0.0] `openChannel` to always have a valid channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,12 +84,6 @@ client.open({ context, fetchConnectionMetadata }, function onOpen({ channel, con
 
 // See docs for exec service here https://crosis-doc.util.repl.co/services#exec
 const closeChannel = client.openChannel({ service: 'exec' }, function open({ channel, context }) {
-  if (!channel) {
-    // Closed before ever connecting. Due to `client.close` being called, `closeChannel` being called
-    // or an unrecoverable, that can be handled by setting `client.setUnrecoverableErr
-    return;
-  }
-
   channel.onCommand((cmd) => {
     if (cmd.output) {
       terminal.write(cmd.output);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replit/crosis",
-  "version": "9.2.1",
+  "version": "10.0.0",
   "description": "Goval connection and channel manager",
   "files": [
     "/dist"

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -738,45 +738,44 @@ concurrent('client rejects opening same channel twice', (done) => {
   done();
 });
 
-// concurrent(
-//   'allows opening channel with the same name after closing others and client is disconnected',
-//   (done) => {
-//     const client = getClient(done);
+concurrent(
+  'allows opening channel with the same name after closing others and client is disconnected',
+  (done) => {
+    const client = getClient(done);
 
-//     const name = Math.random().toString();
+    const name = Math.random().toString();
 
-//     let calledFirstWithError = false;
-//     const close = client.openChannel({ name, service: 'exec' }, ({ error }) => {
-//       calledFirstWithError = Boolean(error);
-//     });
+    const firstOnConnect = jest.fn();
+    const close = client.openChannel({ name, service: 'exec' }, firstOnConnect);
+    close();
 
-//     close();
-//     // open same name synchronously
-//     client.openChannel(
-//       { name, service: 'exec' },
-//       wrapWithDone(done, ({ channel }) => {
-//         expect(channel).toBeTruthy();
-//         expect(calledFirstWithError).toBeTruthy();
-//         client.close();
+    // open same name synchronously
+    client.openChannel(
+      { name, service: 'exec' },
+      wrapWithDone(done, ({ channel }) => {
+        expect(channel).toBeTruthy();
+        expect(firstOnConnect).not.toHaveBeenCalled();
 
-//         done();
-//       }),
-//     );
+        client.close();
 
-//     client.open(
-//       {
-//         fetchConnectionMetadata: () =>
-//           Promise.resolve({
-//             ...genConnectionMetadata(),
-//             error: null,
-//           }),
-//         WebSocketClass: WebSocket,
-//         context: null,
-//       },
-//       () => {},
-//     );
-//   },
-// );
+        done();
+      }),
+    );
+
+    client.open(
+      {
+        fetchConnectionMetadata: () =>
+          Promise.resolve({
+            ...genConnectionMetadata(),
+            error: null,
+          }),
+        WebSocketClass: WebSocket,
+        context: null,
+      },
+      () => {},
+    );
+  },
+);
 
 concurrent(
   'allows opening channel with the same name after others are closing others and client is connected',

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -561,7 +561,7 @@ concurrent('channel skips opening', (done) => {
       WebSocketClass: WebSocket,
       context: ctx,
     },
-    wrapWithDone(done, ({}) => {
+    wrapWithDone(done, () => {
       setTimeout(() => {
         expect(skipfn).toHaveBeenCalledTimes(1);
         expect(skipfn).toHaveBeenCalledWith(ctx);

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -69,10 +69,9 @@ concurrent('client connect', (done) => {
       WebSocketClass: WebSocket,
       context: ctx,
     },
-    wrapWithDone(done, ({ channel, error, context }) => {
+    wrapWithDone(done, ({ channel, context }) => {
       expect(channel?.status).toBe('open');
       expect(context).toBe(ctx);
-      expect(error).toEqual(null);
 
       client.close();
 
@@ -109,11 +108,10 @@ concurrent('client connect with connection metadata retry', (done) => {
       WebSocketClass: WebSocket,
       context: ctx,
     },
-    wrapWithDone(done, ({ channel, error, context }) => {
+    wrapWithDone(done, ({ channel, context }) => {
       expect(tryCount).toBe(2);
       expect(channel?.status).toBe('open');
       expect(context).toBe(ctx);
-      expect(error).toEqual(null);
 
       client.close();
 
@@ -147,10 +145,9 @@ concurrent('client retries', (done) => {
       WebSocketClass: WebSocket,
       context: null,
     },
-    wrapWithDone(done, ({ channel, error }) => {
+    wrapWithDone(done, ({ channel }) => {
       expect(tryCount).toBe(2);
       expect(channel?.status).toBe('open');
-      expect(error).toEqual(null);
 
       client.close();
 
@@ -165,12 +162,22 @@ concurrent('client retries and caches tokens', (done) => {
   const client = getClient(done);
 
   const fetchConnectionMetadata = jest.fn();
+  const onConnect = jest.fn();
 
   let reconnectCount = 0;
   client.onDebugLog((log) => {
+    if (log.type === 'breadcrumb' && log.message === 'client closed') {
+      expect(fetchConnectionMetadata).toHaveBeenCalledTimes(1);
+      expect(onConnect).not.toHaveBeenCalled();
+      done();
+
+      return;
+    }
+
     if (log.type !== 'breadcrumb' || log.message !== 'retrying') {
       return;
     }
+
     reconnectCount += 1;
     if (reconnectCount >= 2) {
       setTimeout(() => {
@@ -195,18 +202,7 @@ concurrent('client retries and caches tokens', (done) => {
       WebSocketClass: WebSocket,
       context: null,
     },
-    ({ error }) => {
-      expect(fetchConnectionMetadata).toHaveBeenCalledTimes(1);
-
-      expect(error).toBeTruthy();
-      expect(error?.message).toBe('Failed to open');
-
-      // the client will not ever successfully connect, so this cannot be
-      // called in the callback.
-      done();
-
-      return () => {};
-    },
+    onConnect,
   );
 });
 
@@ -214,9 +210,18 @@ concurrent('client retries but does not cache tokens', (done) => {
   const client = getClient(done);
 
   const fetchConnectionMetadata = jest.fn();
+  const onConnect = jest.fn();
 
   let reconnectCount = 0;
   client.onDebugLog((log) => {
+    if (log.type === 'breadcrumb' && log.message === 'client closed') {
+      expect(fetchConnectionMetadata.mock.calls.length).toBeGreaterThan(1);
+      expect(onConnect).not.toHaveBeenCalled();
+      done();
+
+      return;
+    }
+
     if (log.type !== 'breadcrumb' || log.message !== 'retrying') {
       return;
     }
@@ -243,18 +248,7 @@ concurrent('client retries but does not cache tokens', (done) => {
       WebSocketClass: WebSocket,
       context: null,
     },
-    wrapWithDone(done, ({ error }) => {
-      expect(fetchConnectionMetadata.mock.calls.length).toBeGreaterThan(1);
-
-      expect(error).toBeTruthy();
-      expect(error?.message).toBe('Failed to open');
-
-      // the client will not ever successfully connect, so this cannot be
-      // called in the callback.
-      done();
-
-      return () => {};
-    }),
+    onConnect,
   );
 });
 
@@ -267,9 +261,8 @@ concurrent('client requests new connection metadata after intentional close', (d
       WebSocketClass: WebSocket,
       context: null,
     },
-    wrapWithDone(done, ({ channel, error }) => {
+    wrapWithDone(done, ({ channel }) => {
       expect(channel?.status).toBe('open');
-      expect(error).toEqual(null);
 
       client.close();
 
@@ -289,9 +282,8 @@ concurrent('client requests new connection metadata after intentional close', (d
               WebSocketClass: WebSocket,
               context: null,
             },
-            ({ channel: c2, error: e2 }) => {
+            ({ channel: c2 }) => {
               expect(c2?.status).toBe('open');
-              expect(e2).toEqual(null);
               expect(didCallFetchConnectionMetadata).toBeTruthy();
 
               client.close();
@@ -325,9 +317,8 @@ concurrent('channel closing itself when client willReconnect', (done) => {
       WebSocketClass: WebSocket,
       context: null,
     },
-    wrapWithDone(done, ({ channel, error }) => {
+    wrapWithDone(done, ({ channel }) => {
       clientOpenCount += 1;
-      expect(error).toEqual(null);
       expect(channel?.status).toBe('open');
 
       if (!disconnectTriggered) {
@@ -357,9 +348,8 @@ concurrent('channel closing itself when client willReconnect', (done) => {
 
   const close = client.openChannel(
     { service: 'shell' },
-    wrapWithDone(done, ({ channel, error }) => {
+    wrapWithDone(done, ({ channel }) => {
       channelOpenCount += 1;
-      expect(error).toBe(null);
       expect(channel?.status).toBe('open');
 
       return wrapWithDone(done, ({ willReconnect }) => {
@@ -386,8 +376,7 @@ concurrent('channel open and close', (done) => {
       WebSocketClass: WebSocket,
       context: null,
     },
-    wrapWithDone(done, ({ channel, error }) => {
-      expect(error).toEqual(null);
+    wrapWithDone(done, ({ channel }) => {
       expect(channel?.status).toBe('open');
 
       return wrapWithDone(done, () => {
@@ -400,9 +389,8 @@ concurrent('channel open and close', (done) => {
 
   const close = client.openChannel(
     { service: 'shell' },
-    wrapWithDone(done, ({ channel, error }) => {
+    wrapWithDone(done, ({ channel }) => {
       expect(channel?.status).toBe('open');
-      expect(error).toBe(null);
 
       setTimeout(() => {
         close();
@@ -432,8 +420,7 @@ concurrent('channel accepts a thunk for service', (done) => {
       WebSocketClass: WebSocket,
       context,
     },
-    wrapWithDone(done, ({ channel, error }) => {
-      expect(error).toEqual(null);
+    wrapWithDone(done, ({ channel }) => {
       expect(channel?.status).toBe('open');
 
       return wrapWithDone(done, () => {
@@ -452,9 +439,8 @@ concurrent('channel accepts a thunk for service', (done) => {
         return 'exec';
       }),
     },
-    wrapWithDone(done, ({ channel, error }) => {
+    wrapWithDone(done, ({ channel }) => {
       expect(channel?.status).toBe('open');
-      expect(error).toBe(null);
 
       setTimeout(
         wrapWithDone(done, () => {
@@ -485,8 +471,7 @@ concurrent('channel open and close from within openChannelCb synchronously', (do
       WebSocketClass: WebSocket,
       context: null,
     },
-    wrapWithDone(done, ({ channel, error }) => {
-      expect(error).toEqual(null);
+    wrapWithDone(done, ({ channel }) => {
       expect(channel?.status).toBe('open');
 
       return wrapWithDone(done, () => {
@@ -499,9 +484,8 @@ concurrent('channel open and close from within openChannelCb synchronously', (do
 
   const close = client.openChannel(
     { service: 'shell' },
-    wrapWithDone(done, ({ channel, error }) => {
+    wrapWithDone(done, ({ channel }) => {
       expect(channel?.status).toBe('open');
-      expect(error).toBe(null);
 
       close();
 
@@ -529,8 +513,7 @@ concurrent('channel open and close from within openChannelCb synchronously', (do
       WebSocketClass: WebSocket,
       context: null,
     },
-    wrapWithDone(done, ({ channel, error }) => {
-      expect(error).toEqual(null);
+    wrapWithDone(done, ({ channel }) => {
       expect(channel?.status).toBe('open');
 
       return () => {
@@ -543,9 +526,8 @@ concurrent('channel open and close from within openChannelCb synchronously', (do
 
   const close = client.openChannel(
     { service: 'shell' },
-    wrapWithDone(done, ({ channel, error }) => {
+    wrapWithDone(done, ({ channel }) => {
       expect(channel?.status).toBe('open');
-      expect(error).toBe(null);
 
       close();
 
@@ -579,9 +561,7 @@ concurrent('channel skips opening', (done) => {
       WebSocketClass: WebSocket,
       context: ctx,
     },
-    wrapWithDone(done, ({ error }) => {
-      expect(error).toBeNull();
-
+    wrapWithDone(done, ({}) => {
       setTimeout(() => {
         expect(skipfn).toHaveBeenCalledTimes(1);
         expect(skipfn).toHaveBeenCalledWith(ctx);
@@ -605,67 +585,66 @@ concurrent('channel skips opening', (done) => {
   );
 });
 
-concurrent('channel skips opening conditionally', (done) => {
-  let unexpectedDisconnectTriggered = false;
-  let clientOpenCount = 0;
-  let channelOpenCount = 0;
+// concurrent('channel skips opening conditionally', (done) => {
+//   let unexpectedDisconnectTriggered = false;
+//   let clientOpenCount = 0;
+//   let channelOpenCount = 0;
 
-  const client = getClient(done);
+//   const client = getClient(done);
 
-  client.open(
-    {
-      fetchConnectionMetadata: getConnectionMetadata,
-      WebSocketClass: WebSocket,
-      context: null,
-    },
-    wrapWithDone(done, ({ channel, error }) => {
-      clientOpenCount += 1;
-      expect(channel?.status).toBe('open');
-      expect(error).toEqual(null);
-      if (unexpectedDisconnectTriggered) {
-        client.close();
-      }
+//   client.open(
+//     {
+//       fetchConnectionMetadata: getConnectionMetadata,
+//       WebSocketClass: WebSocket,
+//       context: null,
+//     },
+//     wrapWithDone(done, ({ channel }) => {
+//       clientOpenCount += 1;
+//       expect(channel?.status).toBe('open');
 
-      return wrapWithDone(done, ({ willReconnect }) => {
-        if (willReconnect) {
-          return;
-        }
+//       if (unexpectedDisconnectTriggered) {
+//         client.close();
+//       }
 
-        expect(clientOpenCount).toEqual(2);
-        expect(channelOpenCount).toEqual(1);
+//       return wrapWithDone(done, ({ willReconnect }) => {
+//         if (willReconnect) {
+//           return;
+//         }
 
-        done();
-      });
-    }),
-  );
+//         expect(clientOpenCount).toEqual(2);
+//         expect(channelOpenCount).toEqual(1);
 
-  client.openChannel(
-    {
-      skip: () => channelOpenCount > 0,
-      service: 'shell',
-    },
-    wrapWithDone(done, ({ channel, error }) => {
-      if (!unexpectedDisconnectTriggered) {
-        setTimeout(() => {
-          // eslint-disable-next-line
-          // @ts-ignore: trigger unintentional disconnect
-          client.ws.close();
-          unexpectedDisconnectTriggered = true;
-        });
+//         done();
+//       });
+//     }),
+//   );
 
-        expect(error).toBe(null);
-        expect(channel?.status).toBe('open');
+//   client.openChannel(
+//     {
+//       skip: () => channelOpenCount > 0,
+//       service: 'shell',
+//     },
+//     wrapWithDone(done, ({ channel }) => {
+//       if (!unexpectedDisconnectTriggered) {
+//         setTimeout(() => {
+//           // eslint-disable-next-line
+//           // @ts-ignore: trigger unintentional disconnect
+//           client.ws.close();
+//           unexpectedDisconnectTriggered = true;
+//         });
 
-        channelOpenCount += 1;
+//         expect(channel?.status).toBe('open');
 
-        return;
-      }
+//         channelOpenCount += 1;
 
-      expect(error).toBeTruthy();
-      expect(error?.message).toBe('Failed to open');
-    }),
-  );
-});
+//         return;
+//       }
+
+//       expect(error).toBeTruthy();
+//       expect(error?.message).toBe('Failed to open');
+//     }),
+//   );
+// });
 
 concurrent('openChannel before open', (done) => {
   const client = getClient(done);
@@ -759,45 +738,45 @@ concurrent('client rejects opening same channel twice', (done) => {
   done();
 });
 
-concurrent(
-  'allows opening channel with the same name after closing others and client is disconnected',
-  (done) => {
-    const client = getClient(done);
+// concurrent(
+//   'allows opening channel with the same name after closing others and client is disconnected',
+//   (done) => {
+//     const client = getClient(done);
 
-    const name = Math.random().toString();
+//     const name = Math.random().toString();
 
-    let calledFirstWithError = false;
-    const close = client.openChannel({ name, service: 'exec' }, ({ error }) => {
-      calledFirstWithError = Boolean(error);
-    });
+//     let calledFirstWithError = false;
+//     const close = client.openChannel({ name, service: 'exec' }, ({ error }) => {
+//       calledFirstWithError = Boolean(error);
+//     });
 
-    close();
-    // open same name synchronously
-    client.openChannel(
-      { name, service: 'exec' },
-      wrapWithDone(done, ({ channel }) => {
-        expect(channel).toBeTruthy();
-        expect(calledFirstWithError).toBeTruthy();
-        client.close();
+//     close();
+//     // open same name synchronously
+//     client.openChannel(
+//       { name, service: 'exec' },
+//       wrapWithDone(done, ({ channel }) => {
+//         expect(channel).toBeTruthy();
+//         expect(calledFirstWithError).toBeTruthy();
+//         client.close();
 
-        done();
-      }),
-    );
+//         done();
+//       }),
+//     );
 
-    client.open(
-      {
-        fetchConnectionMetadata: () =>
-          Promise.resolve({
-            ...genConnectionMetadata(),
-            error: null,
-          }),
-        WebSocketClass: WebSocket,
-        context: null,
-      },
-      () => {},
-    );
-  },
-);
+//     client.open(
+//       {
+//         fetchConnectionMetadata: () =>
+//           Promise.resolve({
+//             ...genConnectionMetadata(),
+//             error: null,
+//           }),
+//         WebSocketClass: WebSocket,
+//         context: null,
+//       },
+//       () => {},
+//     );
+//   },
+// );
 
 concurrent(
   'allows opening channel with the same name after others are closing others and client is connected',
@@ -814,13 +793,7 @@ concurrent(
         WebSocketClass: WebSocket,
         context: null,
       },
-      wrapWithDone(done, ({ error }) => {
-        if (error) {
-          done(error);
-
-          return () => {};
-        }
-
+      wrapWithDone(done, () => {
         const name = Math.random().toString();
 
         let firstChannel: Channel;
@@ -959,8 +932,7 @@ concurrent('client reconnects unexpected disconnects', (done) => {
       WebSocketClass: WebSocket,
       context: null,
     },
-    wrapWithDone(done, ({ channel, error }) => {
-      expect(error).toEqual(null);
+    wrapWithDone(done, ({ channel }) => {
       expect(channel?.status).toEqual('open');
 
       timesConnected += 1;
@@ -1014,8 +986,7 @@ concurrent(
     await new Promise<Channel>((resolve) => {
       client.open(
         connectArgs,
-        wrapWithDone(done, ({ channel, error }) => {
-          expect(error).toEqual(null);
+        wrapWithDone(done, ({ channel }) => {
           expect(channel?.status).toEqual('open');
 
           if (!channel) {
@@ -1088,46 +1059,46 @@ concurrent('client is closed while reconnecting', (done) => {
   );
 });
 
-concurrent('closing before ever connecting', (done) => {
-  const client = getClient(done);
-  client.onDebugLog((log) => {
-    if (log.type === 'breadcrumb' && log.message === 'connecting') {
-      setTimeout(() => {
-        client.close();
-      });
-    }
-  });
+// concurrent('closing before ever connecting', (done) => {
+//   const client = getClient(done);
+//   client.onDebugLog((log) => {
+//     if (log.type === 'breadcrumb' && log.message === 'connecting') {
+//       setTimeout(() => {
+//         client.close();
+//       });
+//     }
+//   });
 
-  const open = jest.fn();
-  const openError = jest.fn();
-  const close = jest.fn();
+//   const open = jest.fn();
+//   const openError = jest.fn();
+//   const close = jest.fn();
 
-  client.open(
-    {
-      fetchConnectionMetadata: getConnectionMetadata,
-      WebSocketClass: WebSocket,
-      context: null,
-    },
-    wrapWithDone(done, ({ error }) => {
-      if (error) {
-        openError();
-        expect(open).not.toHaveBeenCalled();
-        expect(openError).toHaveBeenCalledTimes(1);
-        expect(close).not.toHaveBeenCalled();
+//   client.open(
+//     {
+//       fetchConnectionMetadata: getConnectionMetadata,
+//       WebSocketClass: WebSocket,
+//       context: null,
+//     },
+//     wrapWithDone(done, ({ error }) => {
+//       if (error) {
+//         openError();
+//         expect(open).not.toHaveBeenCalled();
+//         expect(openError).toHaveBeenCalledTimes(1);
+//         expect(close).not.toHaveBeenCalled();
 
-        // the client will not ever successfully connect, so this cannot be
-        // called in the callback.
-        done();
-      } else {
-        open();
-      }
+//         // the client will not ever successfully connect, so this cannot be
+//         // called in the callback.
+//         done();
+//       } else {
+//         open();
+//       }
 
-      return () => {
-        close();
-      };
-    }),
-  );
-});
+//       return () => {
+//         close();
+//       };
+//     }),
+//   );
+// });
 
 concurrent(
   'fallback to polling',
@@ -1154,8 +1125,7 @@ concurrent(
         context: null,
         pollingHost: 'gp-v2.replit.com',
       },
-      wrapWithDone(done, ({ channel, error }) => {
-        expect(error).toBeNull();
+      wrapWithDone(done, ({ channel }) => {
         expect(channel).not.toBeNull();
         expect(didLogFallback).toBe(true);
         client.close();
@@ -1173,7 +1143,17 @@ concurrent(
   'does not fallback to polling if host is unset',
   (done) => {
     const client = getClient(done);
+
+    const onConnect = jest.fn();
     client.setUnrecoverableErrorHandler(() => {});
+    client.onDebugLog((log) => {
+      if (log.type === 'breadcrumb' && log.message === 'client closed') {
+        expect(didLogFallback).toBe(false);
+        expect(onConnect).not.toHaveBeenCalled();
+
+        done();
+      }
+    });
 
     const WebsocketThatNeverConnects = getWebsocketClassThatNeverConnects();
 
@@ -1201,13 +1181,7 @@ concurrent(
         WebSocketClass: WebsocketThatNeverConnects,
         context: null,
       },
-      wrapWithDone(done, ({ channel, error }) => {
-        expect(didLogFallback).toBe(false);
-        expect(channel).toBeNull();
-        expect(error).not.toBeNull();
-
-        done();
-      }),
+      onConnect,
     );
   },
   40000,
@@ -1258,7 +1232,7 @@ concurrent('fetch token fail', (done) => {
 
   client.setUnrecoverableErrorHandler(
     wrapWithDone(done, (e) => {
-      expect(chan0Cb).toHaveBeenCalledTimes(1);
+      expect(chan0Cb).toHaveBeenCalledTimes(0);
       expect(e.message).toContain('fail');
 
       done();
@@ -1282,6 +1256,17 @@ concurrent('fetch abort signal works as expected', (done) => {
   const client = getClient(done);
 
   const onAbort = jest.fn();
+  const onConnect = jest.fn();
+
+  client.onDebugLog((log) => {
+    if (log.type === 'breadcrumb' && log.message === 'client closed') {
+      // wait for the abort signal to be handled
+      expect(onAbort).toHaveBeenCalledTimes(1);
+      expect(onConnect).not.toHaveBeenCalled();
+
+      done();
+    }
+  });
 
   client.open(
     {
@@ -1303,18 +1288,7 @@ concurrent('fetch abort signal works as expected', (done) => {
       WebSocketClass: WebSocket,
       context: null,
     },
-    wrapWithDone(done, ({ channel, error }) => {
-      expect(channel).toBe(null);
-      expect(error).toBeTruthy();
-      expect(error?.message).toBe('Failed to open');
-      expect(onAbort).toHaveBeenCalledTimes(1);
-
-      // The client will not ever successfully connect, so this cannot be
-      // called in the callback.
-      done();
-
-      return () => {};
-    }),
+    onConnect,
   );
 });
 
@@ -1350,14 +1324,7 @@ concurrent('can close and open in synchronously without aborting fetch token', (
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   resolveFetchToken!({ error: FetchConnectionMetadataError.Aborted });
   expect(onAbort).toHaveBeenCalledTimes(1);
-  expect(firstChan0Cb).toHaveBeenCalledTimes(1);
-  expect(firstChan0Cb).toHaveBeenLastCalledWith(
-    expect.objectContaining({
-      channel: null,
-      context: null,
-      error: expect.any(Error),
-    }),
-  );
+  expect(firstChan0Cb).toHaveBeenCalledTimes(0);
 
   client.open(
     {
@@ -1365,14 +1332,13 @@ concurrent('can close and open in synchronously without aborting fetch token', (
       WebSocketClass: WebSocket,
       context: null,
     },
-    wrapWithDone(done, ({ channel, error }) => {
+    wrapWithDone(done, ({ channel }) => {
       expect(channel?.status).toBe('open');
-      expect(error).toEqual(null);
 
       client.close();
 
       return wrapWithDone(done, () => {
-        expect(firstChan0Cb).toHaveBeenCalledTimes(1);
+        expect(firstChan0Cb).toHaveBeenCalledTimes(0);
 
         done();
       });

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1059,47 +1059,6 @@ concurrent('client is closed while reconnecting', (done) => {
   );
 });
 
-// concurrent('closing before ever connecting', (done) => {
-//   const client = getClient(done);
-//   client.onDebugLog((log) => {
-//     if (log.type === 'breadcrumb' && log.message === 'connecting') {
-//       setTimeout(() => {
-//         client.close();
-//       });
-//     }
-//   });
-
-//   const open = jest.fn();
-//   const openError = jest.fn();
-//   const close = jest.fn();
-
-//   client.open(
-//     {
-//       fetchConnectionMetadata: getConnectionMetadata,
-//       WebSocketClass: WebSocket,
-//       context: null,
-//     },
-//     wrapWithDone(done, ({ error }) => {
-//       if (error) {
-//         openError();
-//         expect(open).not.toHaveBeenCalled();
-//         expect(openError).toHaveBeenCalledTimes(1);
-//         expect(close).not.toHaveBeenCalled();
-
-//         // the client will not ever successfully connect, so this cannot be
-//         // called in the callback.
-//         done();
-//       } else {
-//         open();
-//       }
-
-//       return () => {
-//         close();
-//       };
-//     }),
-//   );
-// });
-
 concurrent(
   'fallback to polling',
   (done) => {

--- a/src/__testutils__/concurrent.ts
+++ b/src/__testutils__/concurrent.ts
@@ -8,6 +8,7 @@ export function concurrent(
     () =>
       // eslint-disable-next-line no-async-promise-executor
       new Promise<void>(async (resolve, reject) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         function done(err?: any) {
           if (err) {
             reject(err);

--- a/src/client.ts
+++ b/src/client.ts
@@ -81,7 +81,14 @@ export class Client<Ctx = null> {
    * or the client closed permanently. Otherwise it'll be
    * CONNECTED or CONNECTING
    */
-  public connectionState: ConnectionState;
+  private connectionState: ConnectionState;
+
+  /**
+   * A list of listeners for connection state changes.
+   *
+   * @hidden
+   */
+  private connectionStateChangeFuncs: Array<(state: ConnectionState) => void>;
 
   /**
    * The websocket used for communication with the container.
@@ -228,6 +235,7 @@ export class Client<Ctx = null> {
     this.chan0Cb = null;
     this.chan0CleanupCb = null;
     this.connectionState = ConnectionState.DISCONNECTED;
+    this.connectionStateChangeFuncs = [];
     this.debugFuncs = [];
     this.bootStatusFuncs = [];
     this.userUnrecoverableErrorHandler = null;
@@ -411,7 +419,7 @@ export class Client<Ctx = null> {
 
     this.channelRequests.push(channelRequest);
 
-    if (this.connectionState === ConnectionState.CONNECTED && !sameNameChanRequests.length) {
+    if (this.getConnectionState() === ConnectionState.CONNECTED && !sameNameChanRequests.length) {
       // If we're not connected, then the request to open will go out once we're connected.
       // If there are channels with the same name then this request is queued after the other
       // channel(s) with the same name is done closing
@@ -430,7 +438,7 @@ export class Client<Ctx = null> {
         // If we're connected, it means there's an inflight open request
         // then we'll be sending a close request right after it's done opening
         // so that we can use the channel ID when closing
-        if (this.connectionState !== ConnectionState.CONNECTED) {
+        if (this.getConnectionState() !== ConnectionState.CONNECTED) {
           this.channelRequests = this.channelRequests.filter((cr) => cr !== channelRequest);
         }
 
@@ -743,7 +751,7 @@ export class Client<Ctx = null> {
     this.destroyed = true;
     this.debug({ type: 'breadcrumb', message: 'destroy' });
 
-    if (this.connectionState !== ConnectionState.DISCONNECTED) {
+    if (this.getConnectionState() !== ConnectionState.DISCONNECTED) {
       this.close({
         expectReconnect: false,
       });
@@ -804,6 +812,46 @@ export class Client<Ctx = null> {
       }
     };
   };
+
+  /**
+   * Calls all the listeners for connection state updates. All connection state
+   * updates should go through this function.
+   *
+   * @hidden
+   */
+  private setConnectionState = (connectionState: ConnectionState): void => {
+    this.connectionState = connectionState;
+    this.connectionStateChangeFuncs.forEach((f) => f(connectionState));
+  };
+
+  /**
+   * Sets a listener for connection state changes.
+   *
+   * @returns cleanup function that removes the listener
+   */
+  public onConnectionStateChange = (
+    connectionStateChangeFunc: (connectionState: ConnectionState) => void,
+  ): (() => void) => {
+    this.connectionStateChangeFuncs.push(connectionStateChangeFunc);
+
+    return () => {
+      const idx = this.connectionStateChangeFuncs.indexOf(connectionStateChangeFunc);
+      if (idx > -1) {
+        this.connectionStateChangeFuncs.splice(idx, 1);
+      }
+    };
+  };
+
+  /**
+   * Gets the current connection state.
+   *
+   * The listener functions are only called when the connection state changes.
+   * This function can be used to get the current state ahead of setting up a
+   * listener.
+   *
+   * @returns the current ConnectionState
+   * */
+  public getConnectionState = (): ConnectionState => this.connectionState;
 
   /**
    * Adds a listener for BootStatus messages coming in from the backend
@@ -867,7 +915,7 @@ export class Client<Ctx = null> {
       },
     });
 
-    if (this.connectionState !== ConnectionState.DISCONNECTED) {
+    if (this.getConnectionState() !== ConnectionState.DISCONNECTED) {
       const error = new Error('Client must be disconnected to connect');
       this.onUnrecoverableError(error);
 
@@ -918,7 +966,7 @@ export class Client<Ctx = null> {
       return;
     }
 
-    this.connectionState = ConnectionState.CONNECTING;
+    this.setConnectionState(ConnectionState.CONNECTING);
 
     const chan0 = new Channel({
       id: 0,
@@ -1029,7 +1077,7 @@ export class Client<Ctx = null> {
         return;
       }
 
-      if (this.connectionState !== ConnectionState.CONNECTING) {
+      if (this.getConnectionState() !== ConnectionState.CONNECTING) {
         this.onUnrecoverableError(new Error('Client was closed before connecting'));
 
         return;
@@ -1404,7 +1452,8 @@ export class Client<Ctx = null> {
       });
       chan0.handleClose({ initiator: 'client', willReconnect: true });
       delete this.channels[0];
-      this.connectionState = ConnectionState.DISCONNECTED;
+
+      this.setConnectionState(ConnectionState.DISCONNECTED);
       this.connect({ tryCount, websocketFailureCount });
     }, this.connectOptions.getNextRetryDelayMs(tryCount));
   };
@@ -1474,7 +1523,7 @@ export class Client<Ctx = null> {
    * @hidden
    */
   private handleConnect = () => {
-    this.connectionState = ConnectionState.CONNECTED;
+    this.setConnectionState(ConnectionState.CONNECTED);
 
     this.debug({ type: 'breadcrumb', message: 'connected!' });
 
@@ -1486,7 +1535,7 @@ export class Client<Ctx = null> {
 
     // Update socket closure to do something else
     const onClose = (event: CloseEvent | Event) => {
-      if (this.connectionState === ConnectionState.DISCONNECTED) {
+      if (this.getConnectionState() === ConnectionState.DISCONNECTED) {
         this.onUnrecoverableError(
           new Error('Got a close event on socket but client is in disconnected state'),
         );
@@ -1521,7 +1570,7 @@ export class Client<Ctx = null> {
     if (closeResult.closeReason !== ClientCloseReason.Error) {
       // If we got here as a result of an error we'll ignore these assertions to avoid
       // infinite recursion in onUnrecoverableError
-      if (this.connectionState === ConnectionState.DISCONNECTED) {
+      if (this.getConnectionState() === ConnectionState.DISCONNECTED) {
         this.onUnrecoverableError(
           new Error('handleClose is called but client already disconnected'),
         );
@@ -1653,7 +1702,7 @@ export class Client<Ctx = null> {
       return;
     }
 
-    this.connectionState = ConnectionState.DISCONNECTED;
+    this.setConnectionState(ConnectionState.DISCONNECTED);
 
     if (!willClientReconnect) {
       // Client is done being used until the next `open` call.
@@ -1728,7 +1777,7 @@ export class Client<Ctx = null> {
 
     this.redirectInitiatorURL = null;
 
-    if (this.connectionState !== ConnectionState.DISCONNECTED) {
+    if (this.getConnectionState() !== ConnectionState.DISCONNECTED) {
       try {
         this.handleClose({
           closeReason: ClientCloseReason.Error,

--- a/src/client.ts
+++ b/src/client.ts
@@ -1651,6 +1651,11 @@ export class Client<Ctx = null> {
       this.chan0Cb = null;
       this.connectOptions = null;
 
+      this.debug({
+        type: 'breadcrumb',
+        message: 'client closed',
+      });
+
       return;
     }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -572,7 +572,6 @@ export class Client<Ctx = null> {
 
       (channelRequest as ChannelRequest<Ctx>).cleanupCb = openChannelCb({
         channel,
-
         context: this.connectOptions.context,
       });
     });

--- a/src/client.ts
+++ b/src/client.ts
@@ -1642,7 +1642,13 @@ export class Client<Ctx = null> {
       this.chan0CleanupCb = null;
     } else if (!this.chan0Cb && closeResult.closeReason !== ClientCloseReason.Error) {
       // if we got here as a result of an error we're not gonna call onUnrecoverableError again
-      this.onUnrecoverableError(new Error('open should have been called before `handleClose`'));
+      this.onUnrecoverableError(
+        new Error(
+          '`open` should have been called before `handleClose` (no cleanup or callback function, ' +
+            (willClientReconnect ? 'would reconnect' : 'would not reconnect') +
+            ')',
+        ),
+      );
 
       return;
     }

--- a/src/client.ts
+++ b/src/client.ts
@@ -1640,6 +1640,9 @@ export class Client<Ctx = null> {
         willReconnect: willClientReconnect,
       });
       this.chan0CleanupCb = null;
+    } else if (!this.chan0Cb && closeResult.closeReason !== ClientCloseReason.Error) {
+      // if we got here as a result of an error we're not gonna call onUnrecoverableError again
+      this.onUnrecoverableError(new Error('open should have been called before `handleClose`'));
     }
 
     this.connectionState = ConnectionState.DISCONNECTED;

--- a/src/client.ts
+++ b/src/client.ts
@@ -1643,6 +1643,8 @@ export class Client<Ctx = null> {
     } else if (!this.chan0Cb && closeResult.closeReason !== ClientCloseReason.Error) {
       // if we got here as a result of an error we're not gonna call onUnrecoverableError again
       this.onUnrecoverableError(new Error('open should have been called before `handleClose`'));
+
+      return;
     }
 
     this.connectionState = ConnectionState.DISCONNECTED;

--- a/src/client.ts
+++ b/src/client.ts
@@ -432,12 +432,6 @@ export class Client<Ctx = null> {
         // so that we can use the channel ID when closing
         if (this.connectionState !== ConnectionState.CONNECTED) {
           this.channelRequests = this.channelRequests.filter((cr) => cr !== channelRequest);
-
-          channelRequest.openChannelCb({
-            error: new Error('Channel closed before opening'),
-            channel: null,
-            context: this.connectOptions ? this.connectOptions.context : null,
-          });
         }
 
         return;
@@ -578,7 +572,7 @@ export class Client<Ctx = null> {
 
       (channelRequest as ChannelRequest<Ctx>).cleanupCb = openChannelCb({
         channel,
-        error: null,
+
         context: this.connectOptions.context,
       });
     });
@@ -1283,7 +1277,6 @@ export class Client<Ctx = null> {
 
           this.chan0CleanupCb = this.chan0Cb({
             channel: chan0,
-            error: null,
             context: this.connectOptions.context,
           });
 
@@ -1593,14 +1586,6 @@ export class Client<Ctx = null> {
           willReconnect: willChannelReconnect,
         });
         delete this.channels[channelRequest.channelId];
-      } else if (!willChannelReconnect) {
-        // channel won't reconnect and was never opened
-        // we'll call the open channel callback with an error
-        channelRequest.openChannelCb({
-          channel: null,
-          error: new Error('Failed to open'),
-          context: this.connectOptions ? this.connectOptions.context : null,
-        });
       }
 
       const { cleanupCb, closeRequested } = channelRequest;
@@ -1656,19 +1641,6 @@ export class Client<Ctx = null> {
         willReconnect: willClientReconnect,
       });
       this.chan0CleanupCb = null;
-    } else if (!willClientReconnect) {
-      if (this.chan0Cb) {
-        this.chan0Cb({
-          channel: null,
-          error: new Error('Failed to open'),
-          context: this.connectOptions ? this.connectOptions.context : null,
-        });
-      } else if (closeResult.closeReason !== ClientCloseReason.Error) {
-        // if we got here as a result of an error we're not gonna call onUnrecoverableError again
-        this.onUnrecoverableError(new Error('open should have been called before `handleClose`'));
-
-        return;
-      }
     }
 
     this.connectionState = ConnectionState.DISCONNECTED;

--- a/src/types.ts
+++ b/src/types.ts
@@ -74,6 +74,7 @@ export type DebugLogBreadcrumb<Ctx> =
         | 'connected!'
         | 'user close'
         | 'user temporary close'
+        | 'client closed'
         | 'cancel timeout'
         | 'reset timeout'
         | 'connect timeout'

--- a/src/types.ts
+++ b/src/types.ts
@@ -277,11 +277,10 @@ export interface ChannelOptions<Ctx> {
 /**
  * See [[Client.openChannel]]
  */
-export type OpenChannelCb<Ctx> = (
-  res:
-    | { error: null; channel: Channel; context: Ctx }
-    | { error: Error; channel: null; context: Ctx | null },
-) => void | ((reason: ChannelCloseReason) => void);
+export type OpenChannelCb<Ctx> = (res: {
+  channel: Channel;
+  context: Ctx;
+}) => void | ((reason: ChannelCloseReason) => void);
 
 export interface RequestResult extends api.Command {
   channelClosed?: ChannelCloseReason;


### PR DESCRIPTION
Why
===

https://github.com/replit/repl-it-web/pull/28333

Includes #157 now.
