### PR TITLE
Bump caniuse-lite

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2462,15 +2462,10 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001366:
-  version "1.0.30001367"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001367.tgz#2b97fe472e8fa29c78c5970615d7cd2ee414108a"
-  integrity sha512-XDgbeOHfifWV3GEES2B8rtsrADx4Jf+juKX2SICJcaUhjYBO3bR96kvEIHa15VU6ohtOhBZuPGGYGbXMRn0NCw==
-
-caniuse-lite@^1.0.30001332:
-  version "1.0.30001340"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001340.tgz#029a2f8bfc025d4820fafbfaa6259fd7778340c7"
-  integrity sha512-jUNz+a9blQTQVu4uFcn17uAD8IDizPzQkIKh3LCJfg9BkyIqExYYdyc/ZSlWUSKb8iYiXxKsxbv4zYSvkqjrxw==
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001332, caniuse-lite@^1.0.30001366:
+  version "1.0.30001458"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001458.tgz"
+  integrity sha512-lQ1VlUUq5q9ro9X+5gOEyH7i3vm+AYVT1WDCVB69XOZ17KZRhnZ9J0Sqz7wTHQaLBJccNCHq8/Ww5LlOIZbB0w==
 
 caseless@~0.12.0:
   version "0.12.0"


### PR DESCRIPTION
Why
===
```
$ npx update-browserslist-db@latest
Need to install the following packages:
  update-browserslist-db@1.0.10
Ok to proceed? (y)
Latest version:     1.0.30001458
Installed versions: 1.0.30001340, 1.0.30001367
Removing old caniuse-lite from lock file
Installing new caniuse-lite version
$ yarn add -W caniuse-lite
Cleaning package.json dependencies from caniuse-lite
$ yarn remove -W caniuse-lite
caniuse-lite has been successfully updated


$ yarn why caniuse-lite
yarn why v1.22.19
[1/4] Why do we have the module "caniuse-lite"...?
[2/4] Initialising dependency graph...
[3/4] Finding dependency...
[4/4] Calculating file sizes...
=> Found "caniuse-lite@1.0.30001458"
info Reasons this module exists
   - "browserslist" depends on it
   - Hoisted from "browserslist#caniuse-lite"
   - Hoisted from "@babel#helper-compilation-targets#browserslist#caniuse-lite"
   - Hoisted from "@babel#core#@babel#helper-compilation-targets#browserslist#caniuse-lite"
   - Hoisted from "parcel#cssnano#cssnano-preset-default#postcss-merge-rules#caniuse-api#caniuse-lite"
info Disk size without dependencies: "4.05MB"
info Disk size with unique dependencies: "4.05MB"
info Disk size with transitive dependencies: "4.05MB"
info Number of shared dependencies: 0
Done in 0.67s.
```

