### PR TITLE
[minor->10.1.0] Defer close on all user-specified handleConnect events.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replit/crosis",
-  "version": "10.0.0",
+  "version": "10.1.0",
   "description": "Goval connection and channel manager",
   "files": [
     "/dist"

--- a/src/client.ts
+++ b/src/client.ts
@@ -1543,7 +1543,8 @@ export class Client<Ctx = null> {
     this.ws.onclose = onClose;
     this.ws.onerror = onClose;
 
-    // defer closing if the user decides to call client.close inside a callback.
+    // defer closing until the full connect sequence is complete
+    // in case the user decides to call client.close inside a callback.
     const originalClose = this.close;
     this.close = (args) =>
       setTimeout(() => {
@@ -1551,8 +1552,8 @@ export class Client<Ctx = null> {
       }, 0);
 
     // connection state possibly has a listener, so it needs the deferred close.
-    // note that CONNECTED fires _before_ the chan0Cb to match the
-    // original behavior of state being CONNECTED inside the chan0Cb.
+    // note that CONNECTED is set _before_ the chan0Cb to match the
+    // pre-10.1 behavior of state being CONNECTED inside the chan0Cb.
     this.setConnectionState(ConnectionState.CONNECTED);
     this.debug({ type: 'breadcrumb', message: 'connected!' });
 
@@ -1560,7 +1561,6 @@ export class Client<Ctx = null> {
       this.requestOpenChannel(channelRequest);
     });
 
-    // chan0Cb definitely has a callback.
     this.chan0CleanupCb = this.chan0Cb({
       channel: chan0,
       context: this.connectOptions.context,

--- a/src/client.ts
+++ b/src/client.ts
@@ -1543,10 +1543,6 @@ export class Client<Ctx = null> {
     this.ws.onclose = onClose;
     this.ws.onerror = onClose;
 
-    this.channelRequests.forEach((channelRequest) => {
-      this.requestOpenChannel(channelRequest);
-    });
-
     // defer closing if the user decides to call client.close inside a callback.
     const originalClose = this.close;
     this.close = (args) =>
@@ -1559,6 +1555,10 @@ export class Client<Ctx = null> {
     // original behavior of state being CONNECTED inside the chan0Cb.
     this.setConnectionState(ConnectionState.CONNECTED);
     this.debug({ type: 'breadcrumb', message: 'connected!' });
+
+    this.channelRequests.forEach((channelRequest) => {
+      this.requestOpenChannel(channelRequest);
+    });
 
     // chan0Cb definitely has a callback.
     this.chan0CleanupCb = this.chan0Cb({

--- a/src/client.ts
+++ b/src/client.ts
@@ -758,6 +758,7 @@ export class Client<Ctx = null> {
     }
 
     this.debug = () => {};
+    this.connectionStateChangeFuncs = [];
     this.userUnrecoverableErrorHandler = null;
     this.channelRequests = [];
     this.destroyed = true;


### PR DESCRIPTION
Why
===

[As part of 10.0.0](https://github.com/replit/crosis/pull/157), I exposed an observable on `connectionState` for https://github.com/replit/repl-it-web/pull/28349 creating a new place where a listener could call `client.close`. This means we have to defer that close event too.

So, I moved all that related logic inside `handleConnect`. It was only called in the one place anyway.

Also, clear listeners on destroy.