### PR TITLE
Update README.md - We don't return a null channel anymore.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,12 +66,6 @@ const user = { name: 'tim' };
 const context = { user, repl };
 
 client.open({ context, fetchConnectionMetadata }, function onOpen({ channel, context }) {
-  if (!channel) {
-    // Closed before ever connecting. Due to `client.close` being called
-    // or an unrecoverable, that can be handled by setting `client.setUnrecoverableError`
-    return;
-  }
-
   //  The client is now connected (or reconnected in the event that it encountered an unexpected disconnect)
   // `channel` here is channel0 (more info at https://crosis-doc.util.repl.co/protov2)
   // - send commands using `channel.send`


### PR DESCRIPTION
Why
===

After 10.0, we dropped the `{ channel, error }` union, so this should only ever be called with a valid channel now. I updated this in part of the example, but missed this part. The [types are clear](https://github.com/replit/crosis/blob/154bd1b75229058b79f9cdd7fe185d95f5b377d4/src/types.ts#L282).
