### PR TITLE
[10.1.1] Add breadcrumbs for out of sync `channelRequests` and `channels` at cleanup time.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replit/crosis",
-  "version": "10.1.0",
+  "version": "10.1.1",
   "description": "Goval connection and channel manager",
   "files": [
     "/dist"

--- a/src/client.ts
+++ b/src/client.ts
@@ -1680,24 +1680,26 @@ export class Client<Ctx = null> {
     }
 
     if (Object.keys(this.channels).length !== 0) {
+      // this should never happen, because the channelRequests should have
+      // triggered cleanup of all this, so dump a bunch of breadcrumbs to
+      // help chase down how we got here.
+      for (const key in this.channels) {
+        const channel = this.channels[key];
+        this.debug({
+          type: 'breadcrumb',
+          message: 'out of sync channel',
+          data: {
+            id: channel.id,
+            status: channel.status,
+            service: channel.service,
+            name: channel.name,
+          },
+        });
+      }
+
       this.channels = {};
       if (closeResult.closeReason !== ClientCloseReason.Error) {
         // if we got here as a result of an error we're not gonna call onUnrecoverableError again
-        // but we are going to dump a bunch of breadcrumbs to help chase down how we got here.
-
-        for (const key in this.channels) {
-          const channel = this.channels[key];
-          this.debug({
-            type: 'breadcrumb',
-            message: 'out of sync channel',
-            data: {
-              id: channel.id,
-              status: channel.status,
-              service: channel.service,
-              name: channel.name,
-            },
-          });
-        }
 
         this.onUnrecoverableError(
           new Error('channels object should be empty after channelRequests and chan0 cleanup'),

--- a/src/client.ts
+++ b/src/client.ts
@@ -1608,8 +1608,7 @@ export class Client<Ctx = null> {
       closeResult.closeReason === ClientCloseReason.Disconnected ||
       closeResult.closeReason === ClientCloseReason.Temporary;
 
-    for (const key in this.channels) {
-      const channel = this.channels[key];
+    for (const channel of Object.values(this.channels)) {
       this.debug({
         type: 'breadcrumb',
         message: 'channels on close',
@@ -1683,8 +1682,7 @@ export class Client<Ctx = null> {
       // this should never happen, because the channelRequests should have
       // triggered cleanup of all this, so dump a bunch of breadcrumbs to
       // help chase down how we got here.
-      for (const key in this.channels) {
-        const channel = this.channels[key];
+      for (const channel of Object.values(this.channels)) {
         this.debug({
           type: 'breadcrumb',
           message: 'out of sync channel',

--- a/src/types.ts
+++ b/src/types.ts
@@ -65,6 +65,25 @@ export interface OpenOptions<Ctx> extends Partial<ConnectOptions<Ctx>> {
   context: Ctx;
 }
 
+export enum ClientCloseReason {
+  /**
+   * Called `client.close`, expected to stay closed.
+   */
+  Intentional = 'Intentional',
+  /**
+   * Called `client.close`, but we're going to try to reconnect.
+   */
+  Temporary = 'Temporary',
+  /**
+   * The websocket connection died
+   */
+  Disconnected = 'Disconnected',
+  /**
+   * The client encountered an unrecoverable/invariant error
+   */
+  Error = 'Error',
+}
+
 export type DebugLogBreadcrumb<Ctx> =
   | {
       type: 'breadcrumb';
@@ -209,6 +228,24 @@ export type DebugLogBreadcrumb<Ctx> =
       message: 'calling send on a closed client';
       data: {
         channelId: number;
+      };
+    }
+  | {
+      type: 'breadcrumb';
+      message: 'out of sync channel' | 'channels on close';
+      data: {
+        id: number | null;
+        status: string;
+        service: string | undefined;
+        name: ChannelOptions<Ctx>['name'];
+      };
+    }
+  | {
+      type: 'breadcrumb';
+      message: 'handle close';
+      data: {
+        closeReason: ClientCloseReason;
+        connectionState: ConnectionState;
       };
     };
 


### PR DESCRIPTION
Why
===

https://github.com/replit/repl-it-web/pull/28555
https://replit-kq.sentry.io/issues/3965488037