### PR TITLE
[10.2.0] Defer all connection listeners to outside of our synchronous context.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replit/crosis",
-  "version": "10.1.3",
+  "version": "10.2.0",
   "description": "Goval connection and channel manager",
   "files": [
     "/dist"

--- a/src/client.ts
+++ b/src/client.ts
@@ -874,7 +874,15 @@ export class Client<Ctx = null> {
    */
   private setConnectionState = (connectionState: ConnectionState): void => {
     this.connectionState = connectionState;
-    this.connectionStateChangeFuncs.forEach((f) => f(connectionState));
+    setImmediate(() => {
+      // We need to defer these so that the connection state is announced to
+      // a listener _after_ the changes for the connection state have been
+      // applied. For example, if a user listens for connection state changes
+      // and then calls `client.openChannel` in the listener, outstanding
+      // channel requests will be processed before the listener is called.
+
+      this.connectionStateChangeFuncs.forEach((f) => f(connectionState));
+    });
   };
 
   /**

--- a/src/client.ts
+++ b/src/client.ts
@@ -874,7 +874,7 @@ export class Client<Ctx = null> {
    */
   private setConnectionState = (connectionState: ConnectionState): void => {
     this.connectionState = connectionState;
-    setImmediate(() => {
+    setTimeout(() => {
       // We need to defer these so that the connection state is announced to
       // a listener _after_ the changes for the connection state have been
       // applied. For example, if a user listens for connection state changes
@@ -882,7 +882,7 @@ export class Client<Ctx = null> {
       // channel requests will be processed before the listener is called.
 
       this.connectionStateChangeFuncs.forEach((f) => f(connectionState));
-    });
+    }, 0);
   };
 
   /**
@@ -1607,9 +1607,9 @@ export class Client<Ctx = null> {
     // in case the user decides to call client.close inside a callback.
     const originalClose = this.close;
     this.close = (args) =>
-      setImmediate(() => {
+      setTimeout(() => {
         originalClose(args);
-      });
+      }, 0);
 
     // connection state possibly has a listener, so it needs the deferred close.
     // note that CONNECTED is set _before_ the chan0Cb to match the

--- a/src/client.ts
+++ b/src/client.ts
@@ -1607,9 +1607,9 @@ export class Client<Ctx = null> {
     // in case the user decides to call client.close inside a callback.
     const originalClose = this.close;
     this.close = (args) =>
-      setTimeout(() => {
+      setImmediate(() => {
         originalClose(args);
-      }, 0);
+      });
 
     // connection state possibly has a listener, so it needs the deferred close.
     // note that CONNECTED is set _before_ the chan0Cb to match the


### PR DESCRIPTION
Why
===

A bunch of unexpected behavior was introduced by mapping container and Crosis state in https://github.com/replit/crosis/pull/161 because it allowed consumers of this API to make changes _during_ synchronous events.

This prevents that by dumping to the next tick.