### PR TITLE
[10.3.0] Restore out of sync channels invariant.

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1808,10 +1808,12 @@ export class Client<Ctx = null> {
       }
 
       this.channels = {};
-      this.debug({
-        type: 'error',
-        message: 'channels out of sync',
-      });
+
+      this.onUnrecoverableError(
+        new Error('channels out of sync, should have been cleaned up by channelRequests'),
+      );
+
+      return;
     }
 
     if (this.chan0CleanupCb) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -355,10 +355,6 @@ export type DebugLog<Ctx> =
         };
         cmd: api.Command;
       };
-    }
-  | {
-      type: 'error';
-      message: 'channels out of sync';
     };
 
 /**


### PR DESCRIPTION
Why
===

The underlying bug I was chasing down is fixed in #167, we made this non-fatal to suppress the pain workspace-side, but I want to undo all the extra handlers now that this should really mark a significant error. [See resolved error](https://replit-kq.sentry.io/issues/3981034175/?_allp=1&query=channels+out+of+sync&referrer=issue-stream&statsPeriod=14d)