### PR TITLE
[10.3.0] Remove excess logging.

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1686,19 +1686,6 @@ export class Client<Ctx = null> {
       closeResult.closeReason === ClientCloseReason.Disconnected ||
       closeResult.closeReason === ClientCloseReason.Temporary;
 
-    for (const channel of Object.values(this.channels)) {
-      this.debug({
-        type: 'breadcrumb',
-        message: 'channels on close',
-        data: {
-          id: channel.id,
-          status: channel.status,
-          service: channel.service,
-          name: channel.name,
-        },
-      });
-    }
-
     this.channelRequests.forEach((channelRequest) => {
       const willChannelReconnect: boolean = willClientReconnect && !channelRequest.closeRequested;
 
@@ -1721,30 +1708,12 @@ export class Client<Ctx = null> {
       });
 
       if (channelRequest.isOpen) {
-        this.debug({
-          type: 'breadcrumb',
-          message: 'closing: request open',
-          data: {
-            channelId: channelRequest.channelId,
-            service: serviceName,
-          },
-        });
-
         const channel = this.getChannel(channelRequest.channelId);
         channel.handleClose({
           initiator: 'client',
           willReconnect: willChannelReconnect,
         });
         delete this.channels[channelRequest.channelId];
-      } else {
-        this.debug({
-          type: 'breadcrumb',
-          message: 'closing: request not open',
-          data: {
-            channelId: channelRequest.channelId,
-            service: serviceName,
-          },
-        });
       }
 
       const { cleanupCb, closeRequested } = channelRequest;
@@ -1769,15 +1738,6 @@ export class Client<Ctx = null> {
       if (closeRequested || channelRequest.closeRequested) {
         // Channel closed earlier but we couldn't process the close request
         // or closed during cleanupCb that we just called
-        this.debug({
-          type: 'breadcrumb',
-          message: 'filtering channel requests',
-          data: {
-            requests: this.channelRequests.length,
-            closeRequested,
-          },
-        });
-
         this.channelRequests = this.channelRequests.filter((cr) => cr !== channelRequest);
       }
     });

--- a/src/types.ts
+++ b/src/types.ts
@@ -307,30 +307,6 @@ export type DebugLogBreadcrumb<Ctx> =
     }
   | {
       type: 'breadcrumb';
-      message: 'closing: request open';
-      data: {
-        service: string;
-        channelId: number | null;
-      };
-    }
-  | {
-      type: 'breadcrumb';
-      message: 'closing: request not open';
-      data: {
-        service: string;
-        channelId: number | null;
-      };
-    }
-  | {
-      type: 'breadcrumb';
-      message: 'filtering channel requests';
-      data: {
-        requests: number;
-        closeRequested: boolean;
-      };
-    }
-  | {
-      type: 'breadcrumb';
       message: 'requestOpenChannel: channel already exists';
       data: {
         id: number;


### PR DESCRIPTION
Why
===

In chasing down the bug in #167 we added substantial new breadcrumb logging. Most of it just adds Sentry noise for anything but this issue, so I've removed the worst offenders.

I left a few rare breadcrumbs (generally, the special connection state of a filter or open request). I'll follow up right away with a big overhaul of what remains for some semblance of cleanliness.