### PR TITLE
[10.3.0] If the server gives us two channels with the same ID, explode.

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -588,20 +588,9 @@ export class Client<Ctx = null> {
       }
 
       if (this.channels[id] != null) {
-        const serviceName =
-          typeof channelRequest.options.service === 'string'
-            ? channelRequest.options.service
-            : 'from thunk';
+        this.onUnrecoverableError(new Error(`Channel with id ${id} already exists`));
 
-        this.debug({
-          type: 'breadcrumb',
-          message: 'requestOpenChannel: channel already exists',
-          data: {
-            id,
-            name: channelRequest.options.name,
-            service: serviceName,
-          },
-        });
+        return;
       }
 
       const channel = new Channel({


### PR DESCRIPTION
Why
===

I added this check while diagnosing the out of sync channels issue. It is the opposite of that issue though, we just may end up with multiple channel requests that map to the same channel.

I don't trust my understanding of the protocol well enough to know that this should always be fatal; it doesn't occur in my testing nor the test suite, but I'll tag Faris for this review.

If there's a protocol reason not to ship this, I'll propose removing the invariant entirely as its purpose was just diagnostic.