### PR TITLE
[10.3.0] Cleanup and standardize types and names of remaining breadcrumbs.

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -166,7 +166,7 @@ concurrent('client retries and caches tokens', (done) => {
 
   let reconnectCount = 0;
   client.onDebugLog((log) => {
-    if (log.type === 'breadcrumb' && log.message === 'client closed') {
+    if (log.type === 'breadcrumb' && log.message === 'status:closed') {
       expect(fetchConnectionMetadata).toHaveBeenCalledTimes(1);
       expect(onConnect).not.toHaveBeenCalled();
       done();
@@ -174,7 +174,7 @@ concurrent('client retries and caches tokens', (done) => {
       return;
     }
 
-    if (log.type !== 'breadcrumb' || log.message !== 'retrying') {
+    if (log.type !== 'breadcrumb' || log.message !== 'status:retrying') {
       return;
     }
 
@@ -214,7 +214,7 @@ concurrent('client retries but does not cache tokens', (done) => {
 
   let reconnectCount = 0;
   client.onDebugLog((log) => {
-    if (log.type === 'breadcrumb' && log.message === 'client closed') {
+    if (log.type === 'breadcrumb' && log.message === 'status:closed') {
       expect(fetchConnectionMetadata.mock.calls.length).toBeGreaterThan(1);
       expect(onConnect).not.toHaveBeenCalled();
       done();
@@ -222,7 +222,7 @@ concurrent('client retries but does not cache tokens', (done) => {
       return;
     }
 
-    if (log.type !== 'breadcrumb' || log.message !== 'retrying') {
+    if (log.type !== 'breadcrumb' || log.message !== 'status:retrying') {
       return;
     }
     reconnectCount += 1;
@@ -1026,7 +1026,7 @@ concurrent('client is closed while reconnecting', (done) => {
 
   const client = getClient(done);
   client.onDebugLog((log) => {
-    if (log.type === 'breadcrumb' && log.message === 'reconnecting') {
+    if (log.type === 'breadcrumb' && log.message === 'status:reconnecting') {
       setTimeout(() => {
         client.close();
       });
@@ -1068,7 +1068,7 @@ concurrent(
 
     let didLogFallback = false;
     client.onDebugLog((log) => {
-      if (log.type === 'breadcrumb' && log.message === 'polling fallback') {
+      if (log.type === 'breadcrumb' && log.message === 'websocket:polling fallback') {
         didLogFallback = true;
       }
     });
@@ -1106,7 +1106,7 @@ concurrent(
     const onConnect = jest.fn();
     client.setUnrecoverableErrorHandler(() => {});
     client.onDebugLog((log) => {
-      if (log.type === 'breadcrumb' && log.message === 'client closed') {
+      if (log.type === 'breadcrumb' && log.message === 'status:closed') {
         expect(didLogFallback).toBe(false);
         expect(onConnect).not.toHaveBeenCalled();
 
@@ -1120,7 +1120,7 @@ concurrent(
     client.onDebugLog((log) => {
       if (
         log.type === 'breadcrumb' &&
-        log.message === 'connecting' &&
+        log.message === 'status:connecting' &&
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         (log.data as Record<string, any>)?.connectTries === 4
       ) {
@@ -1128,7 +1128,7 @@ concurrent(
           client.destroy();
         });
       }
-      if (log.type === 'breadcrumb' && log.message === 'polling fallback') {
+      if (log.type === 'breadcrumb' && log.message === 'websocket:polling fallback') {
         didLogFallback = true;
       }
     });
@@ -1156,7 +1156,7 @@ concurrent(
     const timeout = 2000;
 
     client.onDebugLog((log) => {
-      if (log.type === 'breadcrumb' && log.message === 'connecting') {
+      if (log.type === 'breadcrumb' && log.message === 'status:connecting') {
         setTimeout(() => {
           client.close();
 
@@ -1218,7 +1218,7 @@ concurrent('fetch abort signal works as expected', (done) => {
   const onConnect = jest.fn();
 
   client.onDebugLog((log) => {
-    if (log.type === 'breadcrumb' && log.message === 'client closed') {
+    if (log.type === 'breadcrumb' && log.message === 'status:closed') {
       // wait for the abort signal to be handled
       expect(onAbort).toHaveBeenCalledTimes(1);
       expect(onConnect).not.toHaveBeenCalled();

--- a/src/__tests__/retry.test.ts
+++ b/src/__tests__/retry.test.ts
@@ -60,7 +60,7 @@ describe('retry handling', () => {
     );
 
     client.onDebugLog((log) => {
-      if (log.type === 'breadcrumb' && log.message === 'unrecoverable error') {
+      if (log.type === 'breadcrumb' && log.message === 'onUnrecoverableError') {
         expect(tryCount).toBe(1);
 
         done();

--- a/src/types.ts
+++ b/src/types.ts
@@ -89,27 +89,21 @@ export type DebugLogBreadcrumb<Ctx> =
       type: 'breadcrumb';
       message:
         | 'constructor'
-        | 'connected!'
-        | 'user close'
-        | 'user temporary close'
-        | 'client closed'
-        | 'cancel timeout'
-        | 'reset timeout'
-        | 'connect timeout'
-        | 'polling fallback'
-        | 'reconnecting'
-        | 'destroy';
+        | 'status:open'
+        | 'status:connected'
+        | 'close:intentional'
+        | 'close:temporary'
+        | 'status:closed'
+        | 'timeout:cancel'
+        | 'timeout:reset'
+        | 'timeout:hit'
+        | 'polling fallback' // TBD.
+        | 'status:reconnecting'
+        | 'status:destroy';
     }
   | {
       type: 'breadcrumb';
-      message: 'open';
-      data: {
-        polling: false;
-      };
-    }
-  | {
-      type: 'breadcrumb';
-      message: 'connecting';
+      message: 'status:connecting';
       data: {
         connectionState: ConnectionState;
         connectTries: number;
@@ -190,19 +184,19 @@ export type DebugLogBreadcrumb<Ctx> =
     }
   | {
       type: 'breadcrumb';
-      message: 'containerState';
+      message: 'container:state';
       data: api.ContainerState.State;
     }
   | {
       type: 'breadcrumb';
-      message: 'wsclose';
+      message: 'websocket:close';
       data?: {
         event: CloseEvent | Event;
       };
     }
   | {
       type: 'breadcrumb';
-      message: 'cleanupSocket';
+      message: 'websocket:cleanup';
       data: {
         hasWs: boolean;
         readyState: WebSocket['readyState'] | null;
@@ -225,10 +219,20 @@ export type DebugLogBreadcrumb<Ctx> =
     }
   | {
       type: 'breadcrumb';
-      message: 'handle channel close';
+      message: 'client:handleClose';
+      data: {
+        closeReason: ClientCloseReason;
+        connectionState: ConnectionState;
+      };
+    }
+  | {
+      type: 'breadcrumb';
+      message: 'client:handleClose:closing channel';
       data: {
         channelId: number | null;
-        serviceName: string | undefined;
+        service: ChannelOptions<Ctx>['service'];
+        name: ChannelOptions<Ctx>['name'];
+
         closeRequested: boolean;
         channelRequestIsOpen: boolean;
         willChannelReconnect: boolean;
@@ -237,16 +241,9 @@ export type DebugLogBreadcrumb<Ctx> =
     }
   | {
       type: 'breadcrumb';
-      message: 'calling send on a closed client';
+      message: 'client:handleClose:out of sync';
       data: {
-        channelId: number;
-      };
-    }
-  | {
-      type: 'breadcrumb';
-      message: 'out of sync channel';
-      data: {
-        id: number | null;
+        channelId: number | null;
         status: string;
         service: string | undefined;
         name: ChannelOptions<Ctx>['name'];
@@ -258,42 +255,34 @@ export type DebugLogBreadcrumb<Ctx> =
       data: {
         id: number | null;
         status: string;
-        service: string | undefined;
+        service: ChannelOptions<Ctx>['service'];
         name: ChannelOptions<Ctx>['name'];
-      };
-    }
-  | {
-      type: 'breadcrumb';
-      message: 'handle close';
-      data: {
-        closeReason: ClientCloseReason;
-        connectionState: ConnectionState;
       };
     }
   | {
       type: 'breadcrumb';
       message: 'open channel delayed';
       data: {
+        service: ChannelOptions<Ctx>['service'];
+        name: ChannelOptions<Ctx>['name'];
         connectionState: ConnectionState;
-        service: string | undefined;
       };
     }
   | {
       type: 'breadcrumb';
       message: 'close channel deemed unnecessary';
       data: {
-        connectionState: ConnectionState;
         channelId: number | null;
-        service: string;
-        channelsCount: number;
-        requestsCount: number;
+        service: ChannelOptions<Ctx>['service'];
+        name: ChannelOptions<Ctx>['name'];
+        connectionState: ConnectionState;
       };
     }
   | {
       type: 'breadcrumb';
       message: 'open channel skipped';
       data: {
-        service: string | undefined;
+        service: ChannelOptions<Ctx>['service'];
         name: ChannelOptions<Ctx>['name'];
       };
     }
@@ -301,17 +290,18 @@ export type DebugLogBreadcrumb<Ctx> =
       type: 'breadcrumb';
       message: 'abandoning close request';
       data: {
-        service: string;
         channelId: number | null;
+        service: ChannelOptions<Ctx>['service'];
+        name: ChannelOptions<Ctx>['name'];
       };
     }
   | {
       type: 'breadcrumb';
       message: 'requestOpenChannel: channel already exists';
       data: {
-        id: number;
+        channelId: number;
+        service: ChannelOptions<Ctx>['service'];
         name: ChannelOptions<Ctx>['name'];
-        service: string;
       };
     };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -91,15 +91,15 @@ export type DebugLogBreadcrumb<Ctx> =
         | 'constructor'
         | 'status:open'
         | 'status:connected'
+        | 'status:closed'
+        | 'status:reconnecting'
+        | 'status:destroy'
         | 'close:intentional'
         | 'close:temporary'
-        | 'status:closed'
         | 'timeout:cancel'
         | 'timeout:reset'
         | 'timeout:hit'
-        | 'polling fallback' // TBD.
-        | 'status:reconnecting'
-        | 'status:destroy';
+        | 'websocket:polling fallback';
     }
   | {
       type: 'breadcrumb';
@@ -114,66 +114,7 @@ export type DebugLogBreadcrumb<Ctx> =
     }
   | {
       type: 'breadcrumb';
-      message: 'openChanres';
-      data: {
-        id: number;
-        state: api.OpenChannelRes['state'];
-        error: string;
-        ref: string;
-      };
-    }
-  | {
-      type: 'breadcrumb';
-      message: 'requestOpenChannel';
-      data?: {
-        name: ChannelOptions<Ctx>['name'];
-        service: ChannelOptions<Ctx>['service'];
-        action: ChannelOptions<Ctx>['action'];
-        ref: string;
-      };
-    }
-  | {
-      type: 'breadcrumb';
-      message: 'requestChannelClose';
-      data: {
-        id: number;
-        name: ChannelOptions<Ctx>['name'];
-        service: ChannelOptions<Ctx>['service'];
-      };
-    }
-  | {
-      type: 'breadcrumb';
-      message: 'requestChannelClose:chan0Closed';
-      data: {
-        id: number;
-        name: ChannelOptions<Ctx>['name'];
-        service: ChannelOptions<Ctx>['service'];
-      };
-    }
-  | {
-      type: 'breadcrumb';
-      message: 'requestChannelClose:closeChanRes';
-      data: {
-        id: number;
-        name: ChannelOptions<Ctx>['name'];
-        service: ChannelOptions<Ctx>['service'];
-        closeStatus: api.CloseChannelRes.Status;
-      };
-    }
-  | {
-      type: 'breadcrumb';
-      message: 'retrying';
-      data: {
-        connectionState: ConnectionState;
-        connectTries: number;
-        websocketFailureCount: number;
-        error: Error;
-        wsReadyState?: WebSocket['readyState'];
-      };
-    }
-  | {
-      type: 'breadcrumb';
-      message: 'redirectInitiatorFallback';
+      message: 'status:retrying';
       data: {
         connectionState: ConnectionState;
         connectTries: number;
@@ -205,14 +146,74 @@ export type DebugLogBreadcrumb<Ctx> =
     }
   | {
       type: 'breadcrumb';
-      message: 'unrecoverable error';
-      data: {
-        message: string;
+      message: 'requestOpenChannel';
+      data?: {
+        name: ChannelOptions<Ctx>['name'];
+        service: ChannelOptions<Ctx>['service'];
+        action: ChannelOptions<Ctx>['action'];
+        ref: string;
       };
     }
   | {
       type: 'breadcrumb';
-      message: 'handling redirect';
+      message: 'requestOpenChannel:openChanRes';
+      data: {
+        id: number;
+        state: api.OpenChannelRes['state'];
+        error: string;
+        ref: string;
+      };
+    }
+  | {
+      type: 'breadcrumb';
+      message: 'requestOpenChannel:explicit skip';
+      data: {
+        service: ChannelOptions<Ctx>['service'];
+        name: ChannelOptions<Ctx>['name'];
+      };
+    }
+  | {
+      type: 'breadcrumb';
+      message: 'requestCloseChannel';
+      data: {
+        id: number;
+        name: ChannelOptions<Ctx>['name'];
+        service: ChannelOptions<Ctx>['service'];
+      };
+    }
+  | {
+      type: 'breadcrumb';
+      message: 'requestCloseChannel:chan0Closed';
+      data: {
+        id: number;
+        name: ChannelOptions<Ctx>['name'];
+        service: ChannelOptions<Ctx>['service'];
+      };
+    }
+  | {
+      type: 'breadcrumb';
+      message: 'requestCloseChannel:closeChanRes';
+      data: {
+        id: number;
+        name: ChannelOptions<Ctx>['name'];
+        service: ChannelOptions<Ctx>['service'];
+        closeStatus: api.CloseChannelRes.Status;
+      };
+    }
+  | {
+      type: 'breadcrumb';
+      message: 'client:redirectInitiatorFallback';
+      data: {
+        connectionState: ConnectionState;
+        connectTries: number;
+        websocketFailureCount: number;
+        error: Error;
+        wsReadyState?: WebSocket['readyState'];
+      };
+    }
+  | {
+      type: 'breadcrumb';
+      message: 'client:handleRedirect';
       data: {
         connectionMetadata: GovalMetadata | null;
       };
@@ -251,17 +252,7 @@ export type DebugLogBreadcrumb<Ctx> =
     }
   | {
       type: 'breadcrumb';
-      message: 'channels on close';
-      data: {
-        id: number | null;
-        status: string;
-        service: ChannelOptions<Ctx>['service'];
-        name: ChannelOptions<Ctx>['name'];
-      };
-    }
-  | {
-      type: 'breadcrumb';
-      message: 'open channel delayed';
+      message: 'client:openChannel:delayed';
       data: {
         service: ChannelOptions<Ctx>['service'];
         name: ChannelOptions<Ctx>['name'];
@@ -270,7 +261,7 @@ export type DebugLogBreadcrumb<Ctx> =
     }
   | {
       type: 'breadcrumb';
-      message: 'close channel deemed unnecessary';
+      message: 'client:closeChannel:channel not open';
       data: {
         channelId: number | null;
         service: ChannelOptions<Ctx>['service'];
@@ -280,15 +271,7 @@ export type DebugLogBreadcrumb<Ctx> =
     }
   | {
       type: 'breadcrumb';
-      message: 'open channel skipped';
-      data: {
-        service: ChannelOptions<Ctx>['service'];
-        name: ChannelOptions<Ctx>['name'];
-      };
-    }
-  | {
-      type: 'breadcrumb';
-      message: 'abandoning close request';
+      message: 'client:closeChannel:already requested';
       data: {
         channelId: number | null;
         service: ChannelOptions<Ctx>['service'];
@@ -297,11 +280,9 @@ export type DebugLogBreadcrumb<Ctx> =
     }
   | {
       type: 'breadcrumb';
-      message: 'requestOpenChannel: channel already exists';
+      message: 'onUnrecoverableError';
       data: {
-        channelId: number;
-        service: ChannelOptions<Ctx>['service'];
-        name: ChannelOptions<Ctx>['name'];
+        message: string;
       };
     };
 


### PR DESCRIPTION
Why
===

I took an opinionated first pass at cleaning these up as part of undoing the unnecessary parts of my 10.0 - 10.2 diagnostic work. This required a little bit of unexpected web-side changes :thinking:, which is done here:  https://github.com/replit/repl-it-web/pull/28977

- Conceptually grouped all breadcrumbs, this should make them easier to filter on in the Sentry UI.
- Renamed ones that were close-but-not-correct mappings to existing function names.
- Always used the derived service/name types; Sentry correctly handles nulling out the thunks anyway.
- Reordered the types file a little so it was more obvious where to put things.

Very open to feedback here, I'm sure there's a better way to do this, I'm just unaware of some of the context of these logs (e.g., maybe the fallback/redirect logs should actually be removed at this point as they don't look to offer a lot of diagnostic value).