### PR TITLE
[10.3.0] Version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replit/crosis",
-  "version": "10.2.0",
+  "version": "10.3.0",
   "description": "Goval connection and channel manager",
   "files": [
     "/dist"


### PR DESCRIPTION
Why
===

Changes included in this version:

- #168 
- #169 
- #170 
- #171 

I'm open to disagreement that changing breadcrumb names is a minor bump; in which case, we go to 11 instead.