### PR TITLE
[10.3.0] Split wrong state during connect() error into two messages

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1128,9 +1128,12 @@ export class Client<Ctx = null> {
       }
 
       if (this.getConnectionState() !== ConnectionState.CONNECTING) {
+        // between the time we started the connect call and now the client changed state.
+        // without hitting the abort controller.
+
         this.onUnrecoverableError(
           new Error(
-            'Client in wrong state during connect(); connected=' +
+            'Client entered wrong state during connect(); connected=' +
               (this.getConnectionState() === ConnectionState.CONNECTED ? 'true' : 'false'),
           ),
         );

--- a/src/client.ts
+++ b/src/client.ts
@@ -1128,7 +1128,12 @@ export class Client<Ctx = null> {
       }
 
       if (this.getConnectionState() !== ConnectionState.CONNECTING) {
-        this.onUnrecoverableError(new Error('Client was closed before connecting'));
+        this.onUnrecoverableError(
+          new Error(
+            'Client in wrong state during connect(); connected=' +
+              (this.getConnectionState() === ConnectionState.CONNECTED ? 'true' : 'false'),
+          ),
+        );
 
         return;
       }


### PR DESCRIPTION
Why
===

This error implies that the state was DISCONNECTED, but we don't actually know that. Instead, break into two error groupings for Sentry purposes. [Discussion here.](https://replit.slack.com/archives/C04EMTVCGEQ/p1678401043142649)