### PR TITLE
[10.3.0] Smarter closed channel error text.

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -15,7 +15,7 @@ export class Channel {
   /**
    * The name of the service associated with the channel.
    */
-  public readonly service?: string;
+  public readonly service: string;
 
   /**
    * The current connection status of the channel.
@@ -71,7 +71,7 @@ export class Channel {
   }: {
     id: number;
     name?: string;
-    service?: string;
+    service: string;
     send: (cmd: api.Command) => void;
     onUnrecoverableError: (e: Error) => void;
   }) {
@@ -99,7 +99,7 @@ export class Channel {
         'Trying to listen to commands on a closed channel ' +
           (this.name ? `(${this.name})` : '') +
           ' for ' +
-          (this.id === 0 ? 'channel 0' : this.service),
+          this.service,
       );
       this.onUnrecoverableError(e);
 

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -95,7 +95,12 @@ export class Channel {
    */
   public onCommand = (listener: (cmd: api.Command) => void): (() => void) => {
     if (this.status === 'closed') {
-      const e = new Error('Trying to listen to commands on a closed channel for ' + this.service);
+      const e = new Error(
+        'Trying to listen to commands on a closed channel ' +
+          (this.name ? `(${this.name})` : '') +
+          ' for ' +
+          (this.id === 0 ? 'channel 0' : this.service),
+      );
       this.onUnrecoverableError(e);
 
       throw e;

--- a/src/client.ts
+++ b/src/client.ts
@@ -1021,6 +1021,7 @@ export class Client<Ctx = null> {
     const chan0 = new Channel({
       id: 0,
       name: 'chan0',
+      service: 'chan0',
       onUnrecoverableError: this.onUnrecoverableError,
       send: this.send,
     });


### PR DESCRIPTION
Why
===

Getting undefined service channels, I assume it is chan0, because no other call does that, but let's clean it up for Sentry anyway.
