### PR TITLE
[11.0.0] Actual version bump.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replit/crosis",
-  "version": "10.2.0",
+  "version": "11.0.0",
   "description": "Goval connection and channel manager",
   "files": [
     "/dist"


### PR DESCRIPTION
I merged the version bump into a dead/merged old branch by mistake. PR had a bad name anyway, since we decided it was a major bump.

Details here: https://github.com/replit/crosis/pull/172