### PR TITLE
[bsod] Abort the fetch metadata request if it is ongoing.

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1477,6 +1477,14 @@ export class Client<Ctx = null> {
           wsReadyState: this.ws ? this.ws.readyState : undefined,
         },
       });
+
+      if (this.fetchTokenAbortController) {
+        // this can happen while we're fetching the token. if so, when we
+        // close chan0, we need to know we're aborted for that request.
+        this.fetchTokenAbortController.abort();
+        this.fetchTokenAbortController = null;
+      }
+
       chan0.handleClose({ initiator: 'client', willReconnect: true });
       delete this.channels[0];
 


### PR DESCRIPTION
Why
===

I believe this is the root cause of [this error](https://replit-kq.sentry.io/issues/3987472868/?project=6229092&query=is%3Aunresolved&referrer=issue-stream&sort=user&statsPeriod=14d) and possibly all our other cases where the AbortController should have been fired but was not.

Linked error results when `chan0` is closed when we call the `onCommand` [during open](https://github.com/replit/crosis/blob/286996a3c210565aaacc034a9a24b5269994bf48/src/client.ts#L1318). The only way for this to happen is for the channel to close during the fetch metadata event.
