### PR TITLE
[12.0.0] Version bump.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replit/crosis",
-  "version": "11.0.0",
+  "version": "12.0.0",
   "description": "Goval connection and channel manager",
   "files": [
     "/dist"


### PR DESCRIPTION
Why
===

When I published 11, I screwed up a fraction of the merge path. Unfortunately, it means the breaking change (#171) was not included in what went out as 11.

So, here we are again. This time with a breaking change (171 take two) and a bug fix.

- #177 
- #176 