### PR TITLE
`Error` :handshake: `CrosisError`

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1095,7 +1095,7 @@ concurrent(
       }),
     );
   },
-  50000,
+  70000,
 );
 
 concurrent(

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1,5 +1,6 @@
 import { api } from '@replit/protocol';
 import type { ChannelCloseReason, RequestResult } from './types';
+import CrosisError from './util/CrosisError';
 
 export class Channel {
   /**
@@ -57,7 +58,7 @@ export class Channel {
    *
    * @hidden
    */
-  private onUnrecoverableError: (e: Error) => void;
+  private onUnrecoverableError: (e: CrosisError) => void;
 
   /**
    * @hidden should only be called by [[Client]]
@@ -73,7 +74,7 @@ export class Channel {
     name?: string;
     service: string;
     send: (cmd: api.Command) => void;
-    onUnrecoverableError: (e: Error) => void;
+    onUnrecoverableError: (e: CrosisError) => void;
   }) {
     this.id = id;
     this.name = name;
@@ -95,7 +96,7 @@ export class Channel {
    */
   public onCommand = (listener: (cmd: api.Command) => void): (() => void) => {
     if (this.status === 'closed') {
-      const e = new Error(
+      const e = new CrosisError(
         'Trying to listen to commands on a closed channel ' +
           (this.name ? `(${this.name})` : '') +
           ' for ' +
@@ -120,14 +121,14 @@ export class Channel {
    */
   public send = (cmdJson: api.ICommand): void => {
     if (this.status === 'closed') {
-      const e = new Error('Calling send on closed channel for ' + this.service);
+      const e = new CrosisError('Calling send on closed channel for ' + this.service);
       this.onUnrecoverableError(e);
 
       throw e;
     }
 
     if (this.status === 'closing') {
-      const e = new Error(
+      const e = new CrosisError(
         'Cannot send any more commands after a close request on channel for ' + this.service,
       );
       this.onUnrecoverableError(e);

--- a/src/client.ts
+++ b/src/client.ts
@@ -1064,8 +1064,10 @@ export class Client<Ctx = null> {
         );
       } catch (e) {
         let err: CrosisError;
-        if (e instanceof Error) {
+        if (e instanceof CrosisError) {
           err = e;
+        } else if (e instanceof Error) {
+          err = new CrosisError(e.message);
         } else if (
           e &&
           typeof e === 'object' &&

--- a/src/client.ts
+++ b/src/client.ts
@@ -1148,7 +1148,7 @@ export class Client<Ctx = null> {
       }
 
       if (connectionMetadata.error) {
-        this.onUnrecoverableError(connectionMetadata.error);
+        this.onUnrecoverableError(CrosisError.fromError(connectionMetadata.error));
 
         return;
       }

--- a/src/client.ts
+++ b/src/client.ts
@@ -1081,6 +1081,13 @@ export class Client<Ctx = null> {
           err = new CrosisError('Unknown error when fetching connection metadata');
         }
 
+        // wrap the error with some context.
+        err = new CrosisError(
+          err.message,
+          { ...err.extras, from: 'fetchConnectionMetadata' },
+          err.tags,
+        );
+
         this.onUnrecoverableError(err);
 
         return;
@@ -1783,6 +1790,10 @@ export class Client<Ctx = null> {
           '`open` should have been called before `handleClose` (no cleanup or callback function, ' +
             (willClientReconnect ? 'would reconnect' : 'would not reconnect') +
             ')',
+          {
+            closeReason: closeResult.closeReason,
+            connectionState: this.getConnectionState(),
+          },
         ),
       );
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 import type { api } from '@replit/protocol';
 import type { Channel } from './channel';
+import CrosisError from './util/CrosisError';
 
 export enum ConnectionState {
   CONNECTING = 0,
@@ -119,7 +120,7 @@ export type DebugLogBreadcrumb<Ctx> =
         connectionState: ConnectionState;
         connectTries: number;
         websocketFailureCount: number;
-        error: Error;
+        error: CrosisError;
         wsReadyState?: WebSocket['readyState'];
       };
     }
@@ -207,7 +208,7 @@ export type DebugLogBreadcrumb<Ctx> =
         connectionState: ConnectionState;
         connectTries: number;
         websocketFailureCount: number;
-        error: Error;
+        error: CrosisError;
         wsReadyState?: WebSocket['readyState'];
       };
     }

--- a/src/util/CrosisError.ts
+++ b/src/util/CrosisError.ts
@@ -15,4 +15,8 @@ export default class CrosisError extends Error {
     this.extras = extras;
     this.tags = tags;
   }
+
+  static fromError(error: Error): CrosisError {
+    return new CrosisError(error.message);
+  }
 }

--- a/src/util/CrosisError.ts
+++ b/src/util/CrosisError.ts
@@ -17,6 +17,9 @@ export default class CrosisError extends Error {
   }
 
   static fromError(error: Error): CrosisError {
-    return new CrosisError(error.message);
+    const crosisError = new CrosisError(error.message);
+    crosisError.stack = error.stack;
+
+    return crosisError;
   }
 }

--- a/src/util/CrosisError.ts
+++ b/src/util/CrosisError.ts
@@ -1,0 +1,18 @@
+export default class CrosisError extends Error {
+  /** extras - a map of event data in a format appropriate to send to an error logging service */
+  public readonly extras: Record<string, unknown> | null;
+  /** tags - a map of tags to their values in a format appropriate to send to an error logging service */
+  public readonly tags: Record<string, string> | null;
+
+  constructor(
+    message: string,
+
+    extras: Record<string, unknown> | null = null,
+    tags: Record<string, string> | null = null,
+  ) {
+    super(message);
+
+    this.extras = extras;
+    this.tags = tags;
+  }
+}

--- a/src/util/CrosisError.ts
+++ b/src/util/CrosisError.ts
@@ -12,6 +12,7 @@ export default class CrosisError extends Error {
   ) {
     super(message);
 
+    this.name = 'CrosisError';
     this.extras = extras;
     this.tags = tags;
   }

--- a/src/util/helpers.ts
+++ b/src/util/helpers.ts
@@ -1,5 +1,6 @@
 import * as urllib from 'url';
 import type { ConnectOptions, GovalMetadata } from '../types';
+import CrosisError from './CrosisError';
 
 const BACKOFF_FACTOR = 1.7;
 const MAX_BACKOFF = 15000;
@@ -34,7 +35,7 @@ export function getWebSocketClass(
 ): typeof WebSocket {
   if (WebSocketClass) {
     if (!isWebSocket(WebSocketClass)) {
-      throw new Error('Passed in WebSocket does not look like a standard WebSocket');
+      throw new CrosisError('Passed in WebSocket does not look like a standard WebSocket');
     }
 
     return WebSocketClass;
@@ -42,13 +43,13 @@ export function getWebSocketClass(
 
   if (typeof WebSocket !== 'undefined') {
     if (!isWebSocket(WebSocket)) {
-      throw new Error('Global WebSocket does not look like a standard WebSocket');
+      throw new CrosisError('Global WebSocket does not look like a standard WebSocket');
     }
 
     return WebSocket;
   }
 
-  throw new Error('Please pass in a WebSocket class or add it to global');
+  throw new CrosisError('Please pass in a WebSocket class or add it to global');
 }
 
 /**


### PR DESCRIPTION
Why
===

We're currently coercing structured data to strings to pass it from Crosis to web to Sentry. This allows us to add some structured data as `tags` or `extras` (aligned with the Sentry concepts) and is extensible for other metadata as necessary.