### PR TITLE
Add some metadata to certain `CrosisError`s.

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -118,7 +118,10 @@ export class Channel {
    */
   public send = (cmdJson: api.ICommand): void => {
     if (this.status === 'closed') {
-      const e = this.wrapError(new CrosisError('Calling send on closed channel.'), cmdJson);
+      const e = this.wrapError(
+        new CrosisError('Calling send on closed channel for ' + this.service),
+        cmdJson,
+      );
       this.onUnrecoverableError(e);
 
       throw e;
@@ -126,7 +129,9 @@ export class Channel {
 
     if (this.status === 'closing') {
       const e = this.wrapError(
-        new CrosisError('Cannot send any more commands after a close request on channel'),
+        new CrosisError(
+          'Cannot send any more commands after a close request on channel for ' + this.service,
+        ),
         cmdJson,
       );
       this.onUnrecoverableError(e);

--- a/src/client.ts
+++ b/src/client.ts
@@ -1783,6 +1783,10 @@ export class Client<Ctx = null> {
           '`open` should have been called before `handleClose` (no cleanup or callback function, ' +
             (willClientReconnect ? 'would reconnect' : 'would not reconnect') +
             ')',
+          {
+            closeReason: closeResult.closeReason,
+            connectionState: this.getConnectionState(),
+          },
         ),
       );
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -1081,6 +1081,13 @@ export class Client<Ctx = null> {
           err = new CrosisError('Unknown error when fetching connection metadata');
         }
 
+        // wrap the error with some context.
+        err = new CrosisError(
+          err.message,
+          { ...err.extras, from: 'fetchConnectionMetadata' },
+          err.tags,
+        );
+
         this.onUnrecoverableError(err);
 
         return;


### PR DESCRIPTION
Why
===

- Trying to listen on closed channel: not a lot of additional debugging value here.
- Send while closed: we get the command, which hopefully lets us trace back the exact call in the service.
- Send while closing: we get the command, which hopefully lets us trace back the exact call in the service.
- `open` should've been called before `handleClose`: minor additive debug value, the connection state _might_ add some insight here, this feels related to #176.
