### PR TITLE
add priority to channel requests

### DIFF
--- a/src/__tests__/sortByPriority.test.ts
+++ b/src/__tests__/sortByPriority.test.ts
@@ -1,4 +1,5 @@
-import { ChannelRequestPriority, sortByPriority } from '../client';
+import { sortByPriority } from '../client';
+import { ChannelRequestPriority } from '../types';
 
 describe('sortByPriority', () => {
   [
@@ -10,12 +11,24 @@ describe('sortByPriority', () => {
       ],
     },
     {
-      input: [{ priority: ChannelRequestPriority.Low }, { priority: undefined }],
-      expected: [{ priority: undefined }, { priority: ChannelRequestPriority.Low }],
+      input: [
+        { priority: ChannelRequestPriority.Low },
+        { priority: ChannelRequestPriority.Medium },
+      ],
+      expected: [
+        { priority: ChannelRequestPriority.Medium },
+        { priority: ChannelRequestPriority.Low },
+      ],
     },
     {
-      input: [{ priority: undefined }, { priority: ChannelRequestPriority.High }],
-      expected: [{ priority: ChannelRequestPriority.High }, { priority: undefined }],
+      input: [
+        { priority: ChannelRequestPriority.Medium },
+        { priority: ChannelRequestPriority.High },
+      ],
+      expected: [
+        { priority: ChannelRequestPriority.High },
+        { priority: ChannelRequestPriority.Medium },
+      ],
     },
   ].forEach(({ input, expected }, index) => {
     it(`sorts by priority: ${index}`, () => {

--- a/src/__tests__/sortByPriority.test.ts
+++ b/src/__tests__/sortByPriority.test.ts
@@ -1,0 +1,25 @@
+import { ChannelRequestPriority, sortByPriority } from '../client';
+
+describe('sortByPriority', () => {
+  [
+    {
+      input: [{ priority: ChannelRequestPriority.Low }, { priority: ChannelRequestPriority.High }],
+      expected: [
+        { priority: ChannelRequestPriority.High },
+        { priority: ChannelRequestPriority.Low },
+      ],
+    },
+    {
+      input: [{ priority: ChannelRequestPriority.Low }, { priority: undefined }],
+      expected: [{ priority: undefined }, { priority: ChannelRequestPriority.Low }],
+    },
+    {
+      input: [{ priority: undefined }, { priority: ChannelRequestPriority.High }],
+      expected: [{ priority: ChannelRequestPriority.High }, { priority: undefined }],
+    },
+  ].forEach(({ input, expected }, index) => {
+    it(`sorts by priority: ${index}`, () => {
+      expect(input.sort(sortByPriority)).toEqual(expected);
+    });
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,4 +13,5 @@ export {
   OpenChannelCb,
   ChannelCloseReason,
   RequestResult,
+  ChannelRequestPriority,
 } from './types';

--- a/src/types.ts
+++ b/src/types.ts
@@ -340,6 +340,12 @@ interface ServiceThunk<Ctx> {
   (context: Ctx): string;
 }
 
+export enum ChannelRequestPriority {
+  High,
+  Medium,
+  Low,
+}
+
 /**
  * See [[Client.openChannel]]
  */
@@ -348,6 +354,7 @@ export interface ChannelOptions<Ctx> {
   service: string | ServiceThunk<Ctx>;
   action?: api.OpenChannel.Action;
   skip?: (context: Ctx) => boolean;
+  priority?: ChannelRequestPriority;
 }
 
 /**


### PR DESCRIPTION
Why
===

Since requests are queued up until we have a connection less time sensitive channels might get priority over others. Adding a way to specify the priority lets the user prioritize certain channel requests  over others

What changed
============

Added an optional priority option to `channelRequest`

Test plan
=========

Added a basic test for the sorting. I think the real test will need to based on metrics from real usage

_Describe what you did to test this change to a level of detail that allows your reviewer to test it_
