### PR TITLE
Add a way to invalidate cached connection metadata

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -242,6 +242,7 @@ export class Client<Ctx = null> {
     this.fetchTokenAbortController = null;
     this.destroyed = false;
     this.connectionMetadata = null;
+    this.forceRefetchNextMetadata = false;
     this.redirectInitiatorURL = null;
 
     this.debug({ type: 'breadcrumb', message: 'constructor' });


### PR DESCRIPTION
Why
===

_Describe what prompted you to make this change, link relevant resources: Asana tasks, Canny report, Slack discussions...etc_

What changed
============

_Describe what changed to a level of detail that someone with no context with your PR could be able to review it_

Test plan
=========

_Describe what you did to test this change to a level of detail that allows your reviewer to test it_
