### PR TITLE
Transactions.

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -3,7 +3,7 @@ import type { ChannelCloseReason, RequestResult } from './types';
 import CrosisError from './util/CrosisError';
 
 type CustomFallbackBehavior = (
-  cmds: api.ICommand[],
+  commands: api.ICommand[],
   failedIndex: number,
   successfulResults: RequestResult[],
   failureResult: RequestResult,
@@ -258,22 +258,22 @@ export class Channel {
    * ])
    */
   public transaction = async (
-    cmds: api.ICommand[],
+    commands: api.ICommand[],
     behavior: TransactionBehavior | CustomFallbackBehavior,
   ): Promise<RequestResult[]> => {
     const responses = [];
-    for (let i = 0; i < cmds.length; i++) {
-      const response = await this.request(cmds[i]);
+    for (let i = 0; i < commands.length; i++) {
+      const response = await this.request(commands[i]);
 
       if (response.channelClosed) {
         if (behavior === 'retry') {
-          return this.transaction(cmds, behavior);
+          return this.transaction(commands, behavior);
         } else if (behavior === 'continue') {
-          return this.transaction(cmds.slice(i), behavior);
+          return this.transaction(commands.slice(i), behavior);
         } else if (behavior === 'throw') {
           throw new Error('Channel closed');
         } else if (typeof behavior === 'function') {
-          return behavior(cmds, i, responses, response);
+          return behavior(commands, i, responses, response);
         } else if (behavior === 'ignore') {
           // the channel is closed, so we can't actually make any more requests
           // so we just return the responses we have.

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -230,7 +230,10 @@ export class Channel {
       } else if (behavior === 'throw') {
         throw new TransactionError(e);
       } else if (behavior === 'ignore') {
-        // do nothing
+        // do nothing, but also return nothing, because we have nothing.
+        // maybe a future concept could attach some partial/yielded results.
+        // up to the point we failed.
+
         return;
       }
 

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -2,6 +2,15 @@ import { api } from '@replit/protocol';
 import type { ChannelCloseReason, RequestResult } from './types';
 import CrosisError from './util/CrosisError';
 
+type CustomFallbackBehavior = (
+  cmds: api.ICommand[],
+  failedIndex: number,
+  successfulResults: RequestResult[],
+  failureResult: RequestResult,
+) => Promise<RequestResult[]>;
+
+type TransactionBehavior = 'retry' | 'continue' | 'throw' | 'ignore' | CustomFallbackBehavior;
+
 export class Channel {
   /**
    * The channel's id, this is supplied to us by the container

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -207,8 +207,8 @@ export class Channel {
   static transaction = async (
     fn: () => Promise<RequestResult>,
     behavior: Omit<TransactionBehavior, 'continue'>,
-    invariant = (e: Error) => true,
-  ) => {
+    invariant = (_error: Error) => true,
+
     try {
       // TODO: check status closed somehow?
 

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -9,7 +9,7 @@ type CustomFallbackBehavior = (
   failureResult: RequestResult,
 ) => Promise<RequestResult[]>;
 
-type TransactionBehavior = 'retry' | 'continue' | 'throw' | 'ignore' | CustomFallbackBehavior;
+type TransactionBehavior = 'retry' | 'continue' | 'throw' | 'ignore';
 
 class TransactionError extends Error {
   constructor(private error: Error) {
@@ -259,8 +259,7 @@ export class Channel {
    */
   public transaction = async (
     cmds: api.ICommand[],
-    behavior: TransactionBehavior,
-    // TODO: maybe async pattern options, like serialize/fire-and-forget
+    behavior: TransactionBehavior | CustomFallbackBehavior,
   ): Promise<RequestResult[]> => {
     const responses = [];
     for (let i = 0; i < cmds.length; i++) {

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -231,7 +231,10 @@ export class Channel {
         throw new TransactionError(e);
       } else if (behavior === 'ignore') {
         // do nothing
+        return;
       }
+
+      throw new Error('Invalid behavior');
     }
   };
 

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -5,7 +5,7 @@ import CrosisError from './util/CrosisError';
 type CustomFallbackBehavior = (
   commands: api.ICommand[],
   failedIndex: number,
-  successfulResults: RequestResult[],
+  successResults: RequestResult[],
   failureResult: RequestResult,
 ) => Promise<RequestResult[]>;
 


### PR DESCRIPTION
Why
===

For reasons related to ergonomics of the API and realism about where and how it is being used. (I think this greatly cleans up a lot of our `channelClosed`/check closed stuff, misuse of which is a source of many visible/Sentry'd quality issues.)

What changed
============

Added `channel.transaction`, a method that lets you run a group of events with defined behavior around the failure mode. 

And `Channel::transaction` which, if both are to be retained, probably needs a more distinct name that can run more complex logic.

It is possible we'll only want to keep one of these or even escalate the concept to a single message or the container service.

Test plan
=========

Literally nothing and there's obvious(ish) bugs in the current take. This will change before the PR becomes non-draft. Just RFC for now.
