### PR TITLE
[:broom:] Make tests run again.

### DIFF
--- a/debug/genConnectionMetadata.js
+++ b/debug/genConnectionMetadata.js
@@ -30,6 +30,10 @@ function genConnectionMetadata(options) {
     language: 'bash',
     slug: Math.random().toString(36).slice(2),
     user: 'crosistest',
+    userId: {
+      id: 8,
+      environment: 'crosistests',
+    },
     bucket: 'test-replit-repls',
   };
 

--- a/debug/genConnectionMetadata.js
+++ b/debug/genConnectionMetadata.js
@@ -31,7 +31,7 @@ function genConnectionMetadata(options) {
     slug: Math.random().toString(36).slice(2),
     user: 'crosistest',
     userId: {
-      id: 8, // arbitrary
+      id: 78171400, // arbitrary (chosen as crc32c("crosis") if you care)
       environment: api.repl.Environment.DEVELOPMENT,
     },
     bucket: 'test-replit-repls',

--- a/debug/genConnectionMetadata.js
+++ b/debug/genConnectionMetadata.js
@@ -32,7 +32,7 @@ function genConnectionMetadata(options) {
     user: 'crosistest',
     userId: {
       id: 8,
-      environment: 'crosistests',
+      environment: api.repl.Environment.DEVELOPMENT,
     },
     bucket: 'test-replit-repls',
   };

--- a/debug/genConnectionMetadata.js
+++ b/debug/genConnectionMetadata.js
@@ -31,7 +31,7 @@ function genConnectionMetadata(options) {
     slug: Math.random().toString(36).slice(2),
     user: 'crosistest',
     userId: {
-      id: 8,
+      id: 8, // arbitrary
       environment: api.repl.Environment.DEVELOPMENT,
     },
     bucket: 'test-replit-repls',

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "engine.io-client": "^3.4.0"
   },
   "devDependencies": {
-    "@replit/protocol": ">=0.2.77",
+    "@replit/protocol": ">=0.3.0",
     "@types/engine.io-client": "^3.1.5",
     "@types/jest": "^27.5.1",
     "@types/node": "^17.0.32",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1495,10 +1495,10 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==
 
-"@replit/protocol@>=0.2.77":
-  version "0.2.93"
-  resolved "https://registry.yarnpkg.com/@replit/protocol/-/protocol-0.2.93.tgz#ce20e8de12f58f19ee1a418dab8771cdb603b6ee"
-  integrity sha512-rUrpHtmgmAErIDdMrNL3xpExylO/9AU+NmqFiYqY5PIBx1MfFsHwrpGMOk5B0uD5lIzvsSDfZl9iKCgBYlfYBQ==
+"@replit/protocol@>=0.3.0":
+  version "0.3.13"
+  resolved "https://registry.yarnpkg.com/@replit/protocol/-/protocol-0.3.13.tgz#6e3bdd9265d6af7c49ffdcb44209474b1e01c79d"
+  integrity sha512-Q0bqywIY915i+/4+LLtPaqDRUy+nZHPMaq6/j++cKmjMh+XYd7POVMPJeG/0yEBIKbm30Efk6J91FtHH1HpIxQ==
   dependencies:
     protobufjs "^6.11.3"
 


### PR DESCRIPTION
Why
===

Effectively all tests are failing because they hit Goval without a required token property added here: https://github.com/replit/goval/pull/9461

```
[Symbol(kType)]: 'close',
[Symbol(kCode)]: 1008,
[Symbol(kReason)]: 'missing user id',
[Symbol(kWasClean)]: true
```

What changed
============

Bumped the protocol dependency and added the required property to the fake test metadata.

Test plan
=========

Run the tests.
