### PR TITLE
[:bulb:] Don't require the user to return Aborted when that is just fed to it by Crosis.

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1114,34 +1114,11 @@ export class Client<Ctx = null> {
       this.fetchTokenAbortControllers.delete(connectionId);
 
       const connectionMetadata = connectionMetadataFetchResult;
-      const aborted = connectionMetadata.error === FetchConnectionMetadataError.Aborted;
 
-      if (abortController.signal.aborted !== aborted) {
-        // the aborted return value and the abort signal should be equivalent
-        if (abortController.signal.aborted) {
-          // In cases where our abort signal has been called means `client.close` was called
-          // that means we shouldn't be calling `handleConnectError` because chan0Cb is null!
-          this.onUnrecoverableError(
-            new CrosisError(
-              'Expected abort returned from fetchConnectionMetadata to be truthy when the controller aborts',
-            ),
-          );
-
-          return;
-        }
-
-        // the user shouldn't return abort without the abort signal being called, if aborting is desired
-        // client.close should be called
-        this.onUnrecoverableError(
-          new CrosisError(
-            'Abort should only be truthy returned when the abort signal is triggered',
-          ),
-        );
-
-        return;
-      }
-
-      if (connectionMetadata.error === FetchConnectionMetadataError.Aborted) {
+      if (
+        abortController.signal.aborted ||
+        connectionMetadata.error === FetchConnectionMetadataError.Aborted
+      ) {
         // Just return. The user called `client.close` leading to a connectionMetadata abort
         // chan0Cb will be called with with an error Channel close, no need to do anything here.
         return;


### PR DESCRIPTION
Why
===

We largely agreed not to do this, or to do it by removing `FetchConnectionMetadataError.Aborted` entirely, but in case we want the discussion, I'm going to open and immediately close this.

These two signals currently have to match (user and API), which means the only way a client is allowed to abort is if the `abortController` said so. With that in mind, it doesn't make a lot of sense to me to require the client to return aborted if we're going to bail anyway.

This is a change that implements that thought. To ship, I'd rather just delete the concept of the client returning aborted entirely and just have its return value as meaningless if we're aborted.

What changed
============

_Describe what changed to a level of detail that someone with no context with your PR could be able to review it_

Test plan
=========

_Describe what you did to test this change to a level of detail that allows your reviewer to test it_
