### PR TITLE
Tweak the consumer + Crosis both sides aborted check to allow Crosis to unilaterally abort.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replit/crosis",
-  "version": "13.0.0",
+  "version": "13.1.0",
   "description": "Goval connection and channel manager",
   "files": [
     "/dist"

--- a/src/client.ts
+++ b/src/client.ts
@@ -1103,36 +1103,11 @@ export class Client<Ctx = null> {
       this.fetchTokenAbortController = null;
 
       const connectionMetadata = connectionMetadataFetchResult;
-      const aborted = connectionMetadata.error === FetchConnectionMetadataError.Aborted;
 
-      if (abortController.signal.aborted !== aborted) {
-        // the aborted return value and the abort signal should be equivalent
-        if (abortController.signal.aborted) {
-          // In cases where our abort signal has been called means `client.close` was called
-          // that means we shouldn't be calling `handleConnectError` because chan0Cb is null!
-          this.onUnrecoverableError(
-            new CrosisError(
-              'Expected abort returned from fetchConnectionMetadata to be truthy when the controller aborts',
-            ),
-          );
-
-          return;
-        }
-
-        // the user shouldn't return abort without the abort signal being called, if aborting is desired
-        // client.close should be called
-        this.onUnrecoverableError(
-          new CrosisError(
-            'Abort should only be truthy returned when the abort signal is triggered',
-          ),
-        );
-
-        return;
-      }
-
-      if (connectionMetadata.error === FetchConnectionMetadataError.Aborted) {
+      if (abortController.signal.aborted) {
         // Just return. The user called `client.close` leading to a connectionMetadata abort
         // chan0Cb will be called with with an error Channel close, no need to do anything here.
+
         return;
       }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -1109,6 +1109,10 @@ export class Client<Ctx = null> {
         // chan0Cb will be called with with an error Channel close, no need to do anything here.
 
         return;
+      } else if (connectionMetadata.error === FetchConnectionMetadataError.Aborted) {
+        this.onUnrecoverableError(
+          new CrosisError('Received aborted metadata, but request was not aborted.'),
+        );
       }
 
       if (connectionMetadata.error === FetchConnectionMetadataError.Retriable) {

--- a/src/client.ts
+++ b/src/client.ts
@@ -1109,10 +1109,14 @@ export class Client<Ctx = null> {
         // chan0Cb will be called with with an error Channel close, no need to do anything here.
 
         return;
-      } else if (connectionMetadata.error === FetchConnectionMetadataError.Aborted) {
+      }
+
+      if (connectionMetadata.error === FetchConnectionMetadataError.Aborted) {
         this.onUnrecoverableError(
           new CrosisError('Received aborted metadata, but request was not aborted.'),
         );
+
+        return;
       }
 
       if (connectionMetadata.error === FetchConnectionMetadataError.Retriable) {

--- a/src/client.ts
+++ b/src/client.ts
@@ -1112,8 +1112,13 @@ export class Client<Ctx = null> {
       }
 
       if (connectionMetadata.error === FetchConnectionMetadataError.Aborted) {
+        // A client cannot unilaterally choose to abort. If the abortController is not aborted
+        // the client must either return an error or valid metadata.
+
         this.onUnrecoverableError(
-          new CrosisError('Received aborted metadata, but request was not aborted.'),
+          new CrosisError(
+            'Client received abort from fetchConnectionMetadata, but the request was not aborted.',
+          ),
         );
 
         return;

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,12 @@ export enum ConnectionState {
 
 export enum FetchConnectionMetadataError {
   /**
+   * Fetch was aborted. A client can return this if they decided not to fetch
+   * connection metadata _because_ the abort controller was already triggered.
+   */
+  Aborted = 'Aborted',
+
+  /**
    * The fetch failed due to a recoverable error (mostly a transient network
    * condition).
    */

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,11 +10,6 @@ export enum ConnectionState {
 
 export enum FetchConnectionMetadataError {
   /**
-   * Fetch was aborted.
-   */
-  Aborted = 'Aborted',
-
-  /**
    * The fetch failed due to a recoverable error (mostly a transient network
    * condition).
    */

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,8 +10,8 @@ export enum ConnectionState {
 
 export enum FetchConnectionMetadataError {
   /**
-   * Fetch was aborted. A client can return this if they decided not to fetch
-   * connection metadata _because_ the abort controller was already triggered.
+   * Fetch was aborted. A client may return this only if 
+   * the `AbortSignal` was already aborted.
    */
   Aborted = 'Aborted',
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,7 +10,7 @@ export enum ConnectionState {
 
 export enum FetchConnectionMetadataError {
   /**
-   * Fetch was aborted. A client may return this only if 
+   * Fetch was aborted. A client may return this only if
    * the `AbortSignal` was already aborted.
    */
   Aborted = 'Aborted',


### PR DESCRIPTION
Why
===

We discussed _removing_ this check, because it was requiring the client to behave in a particular way w.r.t. receiving an abort signal. This tweak changes that requirement without breaking any existing client usages, keeping an invariant assertion, but making it optional on the _did abort_ case.


What changed
============


Before:
- Crosis aborts.
- Consumer _must_ return Aborted. _It turns out this requirement was impossible to satisfy in certain synchronous contexts._

After:
- Crosis aborts.
- Consumer _may_ return Aborted.


Before:
- Crosis _does not_ abort.
- Consumer _may not_ return Aborted.

After:
- Crosis _does not_ abort.
- Consumer _may not_ return Aborted.


Test plan
=========

I'll wire to web and update the appropriate unit tests, but most of the testing is going to take place by releasing this.