### PR TITLE
[deps] Bump minimum protocol version to mitigate some lock file warnings.

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "engine.io-client": "^3.4.0"
   },
   "devDependencies": {
-    "@replit/protocol": ">=0.3.0",
+    "@replit/protocol": ">=0.3.16",
     "@types/engine.io-client": "^3.1.5",
     "@types/jest": "^27.5.1",
     "@types/node": "^17.0.32",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replit/crosis",
-  "version": "13.1.0",
+  "version": "13.1.1",
   "description": "Goval connection and channel manager",
   "files": [
     "/dist"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1495,12 +1495,12 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==
 
-"@replit/protocol@>=0.3.0":
-  version "0.3.13"
-  resolved "https://registry.yarnpkg.com/@replit/protocol/-/protocol-0.3.13.tgz#6e3bdd9265d6af7c49ffdcb44209474b1e01c79d"
-  integrity sha512-Q0bqywIY915i+/4+LLtPaqDRUy+nZHPMaq6/j++cKmjMh+XYd7POVMPJeG/0yEBIKbm30Efk6J91FtHH1HpIxQ==
+"@replit/protocol@>=0.3.16":
+  version "0.3.16"
+  resolved "https://registry.yarnpkg.com/@replit/protocol/-/protocol-0.3.16.tgz#22a225c970ecb7d89875ea469d906e66a1ea5758"
+  integrity sha512-eP2i5gITaj3GFVvslmgM8KOjtdWnGDgqMbFx8J3+TV26tfw/rxH1h8q2lwZTgvWg0jEUx2g8aYID7Yfw8ccT6g==
   dependencies:
-    protobufjs "^6.11.3"
+    protobufjs "^7.2.4"
 
 "@sinclair/typebox@^0.23.3":
   version "0.23.5"
@@ -1609,11 +1609,6 @@
   version "7.0.11"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"
   integrity sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==
-
-"@types/long@^4.0.1":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.2.tgz#b74129719fc8d11c01868010082d483b7545591a"
-  integrity sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==
 
 "@types/node@*":
   version "12.7.5"
@@ -5517,10 +5512,10 @@ log-symbols@^2.2.0:
   dependencies:
     chalk "^2.0.1"
 
-long@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"
-  integrity sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==
+long@^5.0.0:
+  version "5.2.3"
+  resolved "https://registry.yarnpkg.com/long/-/long-5.2.3.tgz#a3ba97f3877cf1d778eccbcb048525ebb77499e1"
+  integrity sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==
 
 loose-envify@^1.0.0:
   version "1.4.0"
@@ -6791,10 +6786,10 @@ proto-list@~1.2.1:
   resolved "https://registry.yarnpkg.com/proto-list/-/proto-list-1.2.4.tgz#212d5bfe1318306a420f6402b8e26ff39647a849"
   integrity sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==
 
-protobufjs@^6.11.3:
-  version "6.11.3"
-  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-6.11.3.tgz#637a527205a35caa4f3e2a9a4a13ddffe0e7af74"
-  integrity sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==
+protobufjs@^7.2.4:
+  version "7.2.4"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.2.4.tgz#3fc1ec0cdc89dd91aef9ba6037ba07408485c3ae"
+  integrity sha512-AT+RJgD2sH8phPmCf7OUZR8xGdcJRga4+1cOaXJ64hvcSkVhNcRHOwIxUatPH15+nj59WAGTDv3LSGZPEQbJaQ==
   dependencies:
     "@protobufjs/aspromise" "^1.1.2"
     "@protobufjs/base64" "^1.1.2"
@@ -6806,9 +6801,8 @@ protobufjs@^6.11.3:
     "@protobufjs/path" "^1.1.2"
     "@protobufjs/pool" "^1.1.0"
     "@protobufjs/utf8" "^1.1.0"
-    "@types/long" "^4.0.1"
     "@types/node" ">=13.7.0"
-    long "^4.0.0"
+    long "^5.0.0"
 
 proxy-addr@~2.0.7:
   version "2.0.7"


### PR DESCRIPTION
Why
===

This closes some warnings. It should otherwise be a no op. Link through to web shows it is a no op. Ask me on Slack if you want me to explain.