### PR TITLE
[13.2.0]

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replit/crosis",
-  "version": "13.1.1",
+  "version": "13.2.0",
   "description": "Goval connection and channel manager",
   "files": [
     "/dist"


### PR DESCRIPTION
Why
===

Just a version bump for publishing. I deemed #189 a minor because its really just a bug fix, if you were using the API as intended, nothing changed.

Ships:

- #189 
- #196 
- #197 

Package version changes appear to be harmless. I'm having trouble getting `pnpm link` to work how I like today, but I did test the major change here on a previous link to web, will fast follow if this goes wrong.
