### PR TITLE
[replitdev] Add `dotdevHostname` to `GovalMetadata` #minor

### DIFF
--- a/debug/genConnectionMetadata.d.ts
+++ b/debug/genConnectionMetadata.d.ts
@@ -14,4 +14,5 @@ export default function genConnectionMetadata(options?: {
   gurl: string;
   conmanURL: string;
   repl: Repl;
+  dotdevHostname: string;
 };

--- a/debug/genConnectionMetadata.js
+++ b/debug/genConnectionMetadata.js
@@ -79,6 +79,7 @@ function genConnectionMetadata(options) {
     gurl: 'wss://eval.global.replit.com',
     conmanURL: 'https://eval.global.replit.com',
     repl,
+    dotdevHostname: `https://${repl.id}-00-replittesting.gloval.replit.dev`,
   };
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replit/crosis",
-  "version": "13.2.0",
+  "version": "13.3.0",
   "description": "Goval connection and channel manager",
   "files": [
     "/dist"

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -196,6 +196,7 @@ concurrent('client retries and caches tokens', (done) => {
           token: 'test - bad connection metadata retries',
           gurl: 'ws://invalid.example.com',
           conmanURL: 'http://invalid.example.com',
+          dotdevHostname: 'https://invalid-00-replittesting.invalid.replit.dev',
           error: null,
         };
       },
@@ -242,6 +243,7 @@ concurrent('client retries but does not cache tokens', (done) => {
           token: 'test - bad connection metadata retries',
           gurl: 'ws://invalid.example.com',
           conmanURL: 'http://invalid.example.com',
+          dotdevHostname: 'https://invalid-00-replittesting.invalid.replit.dev',
           error: null,
         };
       },

--- a/src/client.ts
+++ b/src/client.ts
@@ -1950,6 +1950,7 @@ export class Client<Ctx = null> {
       token: this.connectionMetadata.token,
       conmanURL: this.connectionMetadata.conmanURL,
       gurl: this.connectionMetadata.gurl,
+      dotdevHostname: this.connectionMetadata.dotdevHostname,
     };
     this.redirectInitiatorURL = null;
     const fetchConnectionMetadataResult: FetchConnectionMetadataResult = {
@@ -1998,6 +1999,9 @@ export class Client<Ctx = null> {
       token: this.connectionMetadata.token,
       conmanURL: this.connectionMetadata.conmanURL,
       gurl: url,
+      // Redirects only happen on the same cluster, which means that the replit.dev hostname does
+      // not change.
+      dotdevHostname: this.connectionMetadata.dotdevHostname,
     };
     this.redirectInitiatorURL = this.connectionMetadata.gurl;
     const fetchConnectionMetadataResult: FetchConnectionMetadataResult = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,6 +26,7 @@ export interface GovalMetadata {
   token: string;
   gurl: string;
   conmanURL: string;
+  dotdevHostname: string;
 }
 
 /**


### PR DESCRIPTION
Why
===

We are going to start sending this new field around, and the main project depends on the type declared in this repository to properly plumb that through everywhere.

What changed
============

This change adds `dotdevHostname` to `GovalMetadata` and bumps the version number to indicate that the interface changed in a compatible way.

Test plan
=========

```shell
$ pnpm run typescript:check
```

in the main repository does not show a ton of errors due to missing fields.