### PR TITLE
chore: add nix flake and envrc

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ yarn-error.log*
 .cache/
 
 .env
+.direnv

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1694937365,
+        "narHash": "sha256-iHZSGrb9gVpZRR4B2ishUN/1LRKWtSHZNO37C8z1SmA=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "5d017a8822e0907fb96f7700a319f9fe2434de02",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-23.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,37 @@
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-23.05";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+  }: let
+    inherit (nixpkgs) lib;
+
+    systems = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
+
+    forEachSystem = f:
+      lib.genAttrs systems (
+        system:
+          f (import nixpkgs {
+            inherit system;
+          })
+      );
+  in {
+    devShells = forEachSystem (pkgs: {
+      default = pkgs.mkShell {
+        packages = with pkgs; [
+          yarn
+          python3
+          nodejs
+        ];
+      };
+    });
+  };
+}


### PR DESCRIPTION
Why
===

I wanted to work on Crosis, but we didn't have a dev shell defined like we do in most other projects.

What changed
============

I've added a Nix Flake that provides a dev shell with `yarn`, `python3`, and `nodejs` so that working with the project can be done without needing to manage system dependencies manually. A `.envrc` was also included which enables `direnv` to automatically activate the dev shell when entering the directory.

Test plan
=========

This change does not affect the library in any way. What I did to confirm that this worked was to enter the dev shell with `nix develop` (or direnv) and then attempt to use `yarn` to install dependencies and build the library.
