### PR TITLE
Allow calling close after destroy

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1445,3 +1445,12 @@ concurrent('emits boot status messages', (done) => {
     () => {},
   );
 });
+
+
+concurrent('close after destroy and destroy multiple times', (done) => {
+  const client = getClient<{ username: string }>(done);
+
+  client.destroy();
+  client.close();
+  client.destroy();
+})

--- a/src/client.ts
+++ b/src/client.ts
@@ -766,6 +766,10 @@ export class Client<Ctx = null> {
    *  e.g., a temporary network issue with an explicit reconnect handler.
    */
   public close = ({ expectReconnect } = { expectReconnect: false }): void => {
+    if (this.destroyed) {
+      return;
+    }
+
     this.debug({
       type: 'breadcrumb',
       message: expectReconnect ? 'close:temporary' : 'close:intentional',
@@ -801,6 +805,10 @@ export class Client<Ctx = null> {
    * avoiding leaks.
    */
   public destroy = (): void => {
+    if (this.destroyed) {
+      return;
+    }
+
     this.destroyed = true;
     this.debug({ type: 'breadcrumb', message: 'status:destroy' });
 


### PR DESCRIPTION
Why
===

Seems safe to treat it as a no-op, also helps us deal with react better

What changed
============
- Allow calling close after destroy
- Allow calling destroy multiple times

Test plan
=========
will follow up with a test