### PR TITLE
Bump protobufjs from 7.2.6 to 7.5.5

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -7131,9 +7131,9 @@ prompts@^2.0.1:
     sisteransi "^1.0.5"
 
 protobufjs@^7.2.4:
-  version "7.2.6"
-  resolved "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.6.tgz"
-  integrity sha512-dgJaEDDL6x8ASUZ1YqWciTRrdOuYNzoOf27oHNfdyvKqHr5i0FV7FSLU+aIeFjyFgVxrpTOtQUi0BLLBymZaBw==
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.5.5.tgz#b7089ca4410374c75150baf277353ef76db69f96"
+  integrity sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==
   dependencies:
     "@protobufjs/aspromise" "^1.1.2"
     "@protobufjs/base64" "^1.1.2"


### PR DESCRIPTION
Why
===

Fixes [Dependabot alert #134](https://github.com/replit/crosis/security/dependabot/134) — arbitrary code execution in `protobufjs < 7.5.5` ([GHSA advisory](https://github.com/advisories/GHSA-r784-p33g-96gm) — attackers who can control protobuf definitions can inject arbitrary JS in the `type` field that executes during `decode`).

Originating Slack thread: https://replit.slack.com/archives/D0AH702HZHQ/p1776388262869839

`protobufjs` is pulled in transitively via `@replit/protocol@0.3.16 → protobufjs@^7.2.4`, which was resolving to `7.2.6` in the lockfile.

What changed
============

- `yarn.lock`: bumped `protobufjs` from `7.2.6` → `7.5.5`. No changes to `package.json` — the existing `^7.2.4` constraint in `@replit/protocol` already permits this version, we just re-resolved the lockfile entry. 3 lines changed.

Test plan
=========

- `yarn build` (tsc) — passes.
- `yarn lint` — passes.
- `yarn test` targeted (`sortByPriority`) — passes. (Full `yarn test` hangs on pre-existing open handles unrelated to this change; CI will exercise the full suite.)

Revertibility
=============

Safe to revert. Lockfile-only change; reverting restores the previous `protobufjs@7.2.6` resolution.

~ written by Zerg :space_invader: ([ravenous-scout-d71e](https://zerg.zergrush.dev/chat?id=ravenous-scout-d71e))